### PR TITLE
Add DeepResearch Qwen3-VL graph-RAG, lexical-graph retrieval, VQA eval harness and tooling

### DIFF
--- a/deepresearch_qwen3_vl/.gitignore
+++ b/deepresearch_qwen3_vl/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/deepresearch_qwen3_vl/BYOKG-RAG模块化改造说明.md
+++ b/deepresearch_qwen3_vl/BYOKG-RAG模块化改造说明.md
@@ -1,0 +1,146 @@
+# BYOKG-RAG 模块化改造说明（Graph Evidence Provider）
+
+本次改造将 BYOKG-RAG 从“端到端 KGQA 流程”收敛为可插拔的**图证据获取器**，以便直接挂到 DeepResearch 的工具层。
+
+## 1. 目标接口
+
+### 输入
+- `question`
+- `schema`（必须）
+- `graph_context`（可选）
+
+### 输出
+- `graph_evidence`
+  - `triples`
+  - `paths`
+  - `query_results`
+- `linking_artifacts`
+  - 最终实体、路径、DSL、OpenCypher、reranker 参数
+  - refinement 历史
+- `confidence`
+- `coverage`
+
+---
+
+## 2. 模块落地
+
+新增文件：`byokg_rag.py`
+
+核心类：
+- `BYOKGRAGProvider`
+- `BYOKGValidator`
+- `CypherDSLCompiler`
+- `RerankerConfig`
+
+并在 `tools.py` 中新增工具路由：
+- `retrieve_graph_evidence`
+
+这样上层工作流只需把它当“KG 证据检索工具”，无需暴露内部每一步。
+
+---
+
+## 3. 按要求实现的关键改动
+
+### 3.1 保留多策略 + 迭代 refinement
+
+`BYOKGRAGProvider.retrieve_graph_evidence()` 保留“多轮 refinement”模式，支持：
+- 首轮 `mode=full`
+- 校验失败后 `mode=repair-only`
+
+并记录每轮 `refinement_history`。
+
+### 3.2 新增工程 validator（可恢复分支）
+
+`BYOKGValidator.validate()` 增加以下校验：
+1. `entities` 空/重复/明显噪声过滤
+2. `paths.relation` 必须属于 `schema.relation_types`
+3. OpenCypher 基础检查：至少包含 `MATCH` 与 `RETURN`
+4. 可选 dry-run：注入 `cypher_dry_run` 回调时，执行 `LIMIT 1` 检查
+
+失败后触发 repair-only，输入包含：
+- 错误列表
+- schema 摘要
+- 上一轮 artifacts
+- 上一轮 graph_context
+
+### 3.3 Graph Reranker 动态参数（L/k）
+
+`_dynamic_reranker()` 根据：
+- KG 稠密度（relation_types 数量）
+- 问题是否多跳（关键词）
+
+动态设置：
+- `L`（hop）
+- `k`（top_k）
+
+### 3.4 OpenCypher 改为 DSL 约束输出
+
+不强依赖“自由生成 Cypher”，而是：
+1. linker 生成 schema-constrained DSL(JSON)
+2. `CypherDSLCompiler.compile()` 编译成 Cypher
+3. validator 再做检查/修复
+
+DSL 结构支持：
+- `match`
+- `edges`
+- `where`
+- `return`
+- `sort`
+- `limit`
+
+### 3.5 多策略候选 + 集成重排（新增）
+
+`BYOKGRAGProvider` 现在支持多种 linking strategy 并进行候选集成：
+- `entity_path`
+- `relation_path`
+- `query_shape`
+
+每个策略产出实体/路径/DSL 后会进行打分排序，输出：
+- `linking_artifacts.strategy_ranking`
+- `linking_artifacts.selected_strategy`
+
+并将 top 候选进行实体和路径合并，提升复杂问题的召回稳定性。
+
+### 3.6 Schema Focus/Pruning（新增）
+
+针对大 schema 场景，在调用 linker 前会基于问题词与关系名的匹配构造：
+- `focus_relation_types`
+- `schema_pruned=true`
+
+用于减少搜索空间和噪声路径。
+
+### 3.7 查询执行与证据回填（新增）
+
+新增可选 `cypher_executor` 注入能力，provider 可在生成 Cypher 后执行查询并回填：
+- `graph_evidence.query_results`
+
+同时将查询命中数量纳入 `coverage` 估计。
+
+---
+
+## 4. 与原功能兼容性
+
+- `ToolRouter` 原有工具均保留。
+- 新工具 `retrieve_graph_evidence` 为增量能力，不破坏现有 `search/open_webpage/retrieve_lexical_graph/analyze_image`。
+- 默认 linker 缺省时有 fallback，不会导致调用崩溃。
+
+---
+
+## 5. 建议接入方式（上层）
+
+上层只需在某轮工具调用中传入：
+
+```json
+{
+  "tool_name": "retrieve_graph_evidence",
+  "args": {
+    "question": "...",
+    "schema": {"relation_types": ["..."], "node_types": ["..."], "summary": "..."},
+    "graph_context": "..."
+  }
+}
+```
+
+并基于 `confidence/coverage` 决定是否继续：
+- 低置信/低覆盖：继续外层检索或追问
+- 高置信/高覆盖：直接进入总结/回答

--- a/deepresearch_qwen3_vl/README.md
+++ b/deepresearch_qwen3_vl/README.md
@@ -1,0 +1,454 @@
+# DeepResearch-Qwen3VL（GraphRAG-Lexical 深化版）
+
+这是一个参考 Tongyi-Qwen-DeepResearch 思路、并将基座模型统一为 **Qwen3-VL-8B-Instruct** 的深度研究框架。
+
+本次进一步引入了来自 `awslabs/graphrag-toolkit/lexical-graph` 的关键思想：
+- 分层 lexical graph（source/chunk/entity）
+- 检索时采用“种子召回 + 图遍历扩展”
+- 用于跨文档主题关联与证据补全
+
+> 目标：让 deepresearch 的检索部分从“单跳网页抓取”升级为“知识增强检索”，并支持多模态 VQA 评测。
+
+## 方法理解与接入位置
+
+根据 lexical-graph 的 querying 机制，可抽象为：
+1. 向量/词法相似检索得到初始 seed；
+2. 从 seed 在图中沿主题/实体关系遍历，补全相关证据；
+3. 用聚合结果进行答案生成。
+
+在本项目中的对应接入：
+- 在 `open_webpage` 后，将网页文本 chunk 化，构建轻量 lexical graph；
+- 新增 `retrieve_lexical_graph` 工具执行“词法 seed + 实体扩展”检索；
+- `ResearcherAgent` 在每个子问题结束后自动追加一次 lexical-graph 检索，补充跨文档证据；
+- 再进入 `Critic/Verifier/Synthesizer` 闭环。
+
+## 当前架构
+
+- `PlannerAgent`: 子问题分解（结构化）
+- `ResearcherAgent`: ReAct 式工具调用 + lexical graph 补检索
+- `CriticAgent`: 判断证据充分性并生成追问
+- `VerifierAgent`: 证据筛选
+- `SynthesizerAgent`: 结构化报告生成
+
+## 新增能力
+
+### 1) lexical graph 检索模块
+- 文件：`lexical_graph.py`
+- 关键类：
+  - `LexicalGraphIndex`
+  - `LexicalGraphRetriever`
+- 检索策略：
+  - lexical seed（token overlap + idf）
+  - entity traversal expansion（实体邻接扩展）
+  - rerank（融合 lexical/实体匹配）
+
+### 2) ToolRouter 新工具
+- `retrieve_lexical_graph {question, documents, top_k}`
+
+### 3) 知识增强型多模态 VQA 评测脚本
+- 文件：`eval_vqa.py`
+- 对比：
+  - baseline（直接拼接文档上下文）
+  - graph-enhanced（lexical graph 检索上下文）
+- 指标：
+  - Exact Match
+  - 字符级 F1
+
+## 目录结构
+
+```text
+deepresearch_qwen3_vl/
+├── agents.py
+├── config.py
+├── eval_vqa.py                 # 新增：VQA评测
+├── lexical_graph.py            # 新增：lexical-graph 检索
+├── main.py
+├── models.py
+├── tools.py
+├── workflow.py
+└── requirements.txt
+```
+
+## 运行
+
+### 1) 安装依赖
+
+```bash
+pip install -r requirements.txt
+```
+
+### 2) 配置环境变量
+
+```bash
+export OPENAI_BASE_URL="http://localhost:8000/v1"
+export OPENAI_API_KEY="EMPTY"
+export MODEL_NAME="Qwen/Qwen3-VL-8B-Instruct"
+
+export MAX_RESEARCH_ROUNDS="3"
+export MAX_SNIPPETS_PER_ROUND="5"
+export MAX_ACTIONS_PER_QUESTION="4"
+```
+
+### 3) deepresearch 主流程
+
+```bash
+python main.py "比较2024-2025年主流多模态大模型在文档理解上的优势与局限"
+```
+
+### 4) 运行 VQA 评测
+
+数据格式（JSON 列表，每条包含 `question/answer/documents`，可选 `image_url` 或 `image_path/image/img_path`）：
+
+```json
+[
+  {
+    "question": "图中模型属于哪一类？",
+    "image_url": "https://.../image.png",
+    "answer": "多模态大模型",
+    "documents": [
+      {"source": "doc1", "text": "..."},
+      {"source": "doc2", "text": "..."}
+    ],
+    "image_path": "relative/or/absolute/path/to/image.png"
+  }
+]
+```
+
+运行：
+
+```bash
+python eval_vqa.py /path/to/vqa_dataset.json --out vqa_eval_report.json --image-root /path/to/images
+```
+
+
+支持数据集格式：
+- `.json`（对象列表）
+- `.jsonl`（每行一个对象）
+- `.parquet`（表格列）
+
+Parquet/自定义字段名示例：
+
+```bash
+python eval_vqa.py /data/xxx/test.parquet   --question-field question   --answer-field answer   --image-path-field image_path   --documents-field documents   --image-root /data/xxx/images   --out vqa_eval_report.json
+```
+
+如果你的 parquet 里上下文字段不是 `documents`，而是纯文本列（如 `context`），可用：
+
+
+A-OKVQA parquet 特殊说明：
+- 若 `image` 列是 `{"bytes": ..., "path": ...}` 这类 HuggingFace Image 对象，本脚本会自动将 `bytes` 临时落盘并作为 `file://` 图片输入模型。
+- 该逻辑仅在检测到 `image` 字段且其结构确实包含 `bytes` 时触发；其他数据集不会强制按此方式解析。
+
+
+```bash
+python eval_vqa.py /data/xxx/test.parquet   --documents-field context   --question-field question   --answer-field answer
+```
+
+MMMU_Pro（题目 parquet 与视觉 parquet 分离）说明：
+- `--dataset-type mmmu_pro`：强制走 MMMU_Pro 解析，不影响 A_OKVQA / M3COT 分支。
+- `--mmmu-vision-parquet`：传入视觉 parquet 文件或目录（按 `id` 做 join，可通过 `--mmmu-id-field` / `--mmmu-vision-id-field` 改字段名）。
+- `options/choices` 支持 parquet list，也支持字符串形式（如 `"['A','B',...]"`）。
+- 4 选项和 10 选项都使用同一解析逻辑：模型提示只会按实际选项数量生成 A-D 或 A-J。
+
+## 3) 运行评测
+
+> `run_deepresearch.sh eval` 会把参数原样传给 `eval_vqa.py`，所以两者命令等价。  
+> 注意：`run_deepresearch.sh` 里 `eval` 模式是**位置参数 dataset**（不是 `--dataset`）。
+
+### 3.00) 多模型切换（Qwen3-VL / Qwen2.5-VL / Qwen2-VL）
+
+评测命令可直接加 `--model-name` 指定模型路径（同一套数据集命令可复用）：
+
+```bash
+--model-name /data/zhuxy/multimodal_deepresearch/Qwen3-VL-8B-Instruct
+--model-name /data/zhuxy/multimodal_deepresearch/Qwen2.5-VL-7B-Instruct
+--model-name /data/zhuxy/multimodal_deepresearch/Qwen2-VL-7B-Instruct
+```
+
+如果你连接不同推理服务，也可附加：
+- `--openai-base-url ...`
+- `--openai-api-key ...`
+
+### 3.0) 消融装配开关（按图片里的 7 种设置）
+
+新增 `--ablation-profile`，用于控制推理时是否装配：
+- KG-RAG
+- 难度评估器
+- 首轮推理后的 SFT 精炼
+
+可选值与图片对应关系：
+- `none`：KG-RAG ✗ / 难度评估器 ✗ / SFT ✗
+- `kg_only`：KG-RAG ✓ / 难度评估器 ✗ / SFT ✗
+- `difficulty_only`：KG-RAG ✗ / 难度评估器 ✓ / SFT ✗
+- `kg_difficulty`：KG-RAG ✓ / 难度评估器 ✓ / SFT ✗
+- `kg_sft`：KG-RAG ✓ / 难度评估器 ✗ / SFT ✓
+- `difficulty_sft`：KG-RAG ✗ / 难度评估器 ✓ / SFT ✓
+- `all_on`：KG-RAG ✓ / 难度评估器 ✓ / SFT ✓
+
+示例（只做 KG-RAG，不用难度评估和 SFT）：
+
+```bash
+bash run_deepresearch.sh eval \
+  /path/to/dataset.json \
+  --dataset-type generic \
+  --ablation-profile kg_only \
+  --out /tmp/ablation_kg_only.json
+```
+
+评测结束后，终端会额外打印 `=== Accuracy Stats ===`，并在输出 JSON 中保存：
+- `accuracy_stats.total`
+- `accuracy_stats.baseline_correct`
+- `accuracy_stats.graph_correct`
+- `accuracy_stats.baseline_accuracy`
+- `accuracy_stats.graph_accuracy`
+
+### 3.1) A_OKVQA
+
+```bash
+bash run_deepresearch.sh eval \
+  /data/zhuxy/office/dataset/KG_VQA/A_OKVQA/test-00000-of-00001-d306bf3ad53b6618.parquet \
+  --dataset-type generic \
+  --question-field question \
+  --answer-field answer \
+  --image-path-field image_path \
+  --documents-field documents \
+  --image-root /data/zhuxy/multimodal_deepresearch/A_OKVQA/images/train2017 \
+  --out /data/zhuxy/multimodal_deepresearch/output/aokvqa_eval_report.json \
+  --details-out /data/zhuxy/multimodal_deepresearch/output/aokvqa_eval_details.jsonl \
+  --details-format jsonl
+```
+
+```bash
+# 等价 Python 版本
+python eval_vqa.py \
+  /data/zhuxy/multimodal_deepresearch/A_OKVQA/train-00000-of-00002-c1d24de3bacb5e0c.parquet \
+  --dataset-type generic \
+  --question-field question \
+  --answer-field answer \
+  --documents-field documents \
+  --image-path-field image_path \
+  --image-root /data/zhuxy/multimodal_deepresearch/A_OKVQA/images/train2017 \
+  --out /data/zhuxy/multimodal_deepresearch/output/a_okvqa_report.json \
+  --details-out /data/zhuxy/multimodal_deepresearch/output/a_okvqa_details.jsonl \
+  --details-format jsonl
+```
+
+### 3.2) M3COT
+
+```bash
+bash run_deepresearch.sh eval \
+  /data/zhuxy/multimodal_deepresearch/M3COT/data/train.jsonl \
+  --dataset-type m3cot \
+  --question-field question \
+  --answer-field answer \
+  --image-path-field image \
+  --image-root /data/zhuxy/multimodal_deepresearch/M3COT/data/images \
+  --out /data/zhuxy/multimodal_deepresearch/output/m3cot_report.json \
+  --details-out /data/zhuxy/multimodal_deepresearch/output/m3cot_details.jsonl \
+  --details-format jsonl
+```
+
+```bash
+# 等价 Python 版本
+python eval_vqa.py \
+  /data/zhuxy/multimodal_deepresearch/M3COT/data/train.jsonl \
+  --dataset-type m3cot \
+  --question-field question \
+  --answer-field answer \
+  --image-path-field image \
+  --image-root /data/zhuxy/multimodal_deepresearch/M3COT/data/images \
+  --out /data/zhuxy/multimodal_deepresearch/output/m3cot_report.json \
+  --details-out /data/zhuxy/multimodal_deepresearch/output/m3cot_details.jsonl \
+  --details-format jsonl
+```
+
+### 3.3) MMMU_pro（4 options）
+
+```bash
+bash run_deepresearch.sh eval \
+  /data/zhuxy/multimodal_deepresearch/MMMU_pro/standard_4 \
+  --dataset-type mmmu_pro \
+  --question-field question \
+  --answer-field answer \
+  --mmmu-vision-parquet /data/zhuxy/multimodal_deepresearch/MMMU_pro/vision \
+  --mmmu-id-field id \
+  --mmmu-vision-id-field id \
+  --mmmu-vision-image-field image \
+  --out /data/zhuxy/multimodal_deepresearch/output/mmmu_pro_4_report.json \
+  --details-out /data/zhuxy/multimodal_deepresearch/output/mmmu_pro_4_details.jsonl \
+  --details-format jsonl
+```
+
+```bash
+# 等价 Python 版本
+python eval_vqa.py \
+  /data/zhuxy/multimodal_deepresearch/MMMU_pro/standard_4 \
+  --dataset-type mmmu_pro \
+  --question-field question \
+  --answer-field answer \
+  --mmmu-vision-parquet /data/zhuxy/multimodal_deepresearch/MMMU_pro/vision \
+  --mmmu-id-field id \
+  --mmmu-vision-id-field id \
+  --mmmu-vision-image-field image \
+  --out /data/zhuxy/multimodal_deepresearch/output/mmmu_pro_4_report.json \
+  --details-out /data/zhuxy/multimodal_deepresearch/output/mmmu_pro_4_details.jsonl \
+  --details-format jsonl
+```
+
+### 3.4) MMMU_pro（10 options）
+
+```bash
+bash run_deepresearch.sh eval \
+  /data/zhuxy/multimodal_deepresearch/MMMU_pro/standard_10 \
+  --dataset-type mmmu_pro \
+  --question-field question \
+  --answer-field answer \
+  --mmmu-vision-parquet /data/zhuxy/multimodal_deepresearch/MMMU_pro/vision \
+  --mmmu-id-field id \
+  --mmmu-vision-id-field id \
+  --mmmu-vision-image-field image \
+  --out /data/zhuxy/multimodal_deepresearch/output/mmmu_pro_10_report.json \
+  --details-out /data/zhuxy/multimodal_deepresearch/output/mmmu_pro_10_details.jsonl \
+  --details-format jsonl
+```
+
+### 3.5) CMMQA
+
+```bash
+bash run_deepresearch.sh eval \
+  /data/zhuxy/multimodal_deepresearch/problems_with_urls.json \
+  --dataset-type cmmqa \
+  --question-field question \
+  --answer-field answer \
+  --image-url-field image_url \
+  --image-path-field image \
+  --image-root /data/zhuxy/multimodal_deepresearch \
+  --out /data/zhuxy/multimodal_deepresearch/output/cmmqa_report.json \
+  --details-out /data/zhuxy/multimodal_deepresearch/output/cmmqa_details.jsonl \
+  --details-format jsonl
+```
+
+### 3.6) ScienceQA
+
+> `problems.json` 为 `dict[id -> problem]` 结构；脚本会自动展开并把 `id` 注入样本。  
+> 图像路径按 `images/{split}/{id}/image.png` 规则拼接（例如 `train/1/image.png`）。
+
+```bash
+bash run_deepresearch.sh eval \
+  /data/zhuxy/office/dataset/NOKG_VQA/ScienceQA/data/scienceqa/problems.json \
+  --dataset-type scienceqa \
+  --question-field question \
+  --answer-field answer \
+  --image-path-field image \
+  --image-root /data/zhuxy/office/dataset/NOKG_VQA/ScienceQA/images \
+  --out /data/zhuxy/multimodal_deepresearch/output/scienceqa_report.json \
+  --details-out /data/zhuxy/multimodal_deepresearch/output/scienceqa_details.jsonl \
+  --details-format jsonl
+```
+
+```bash
+# 等价 Python 版本
+python eval_vqa.py \
+  /data/zhuxy/office/dataset/NOKG_VQA/ScienceQA/data/scienceqa/problems.json \
+  --dataset-type scienceqa \
+  --question-field question \
+  --answer-field answer \
+  --image-path-field image \
+  --image-root /data/zhuxy/office/dataset/NOKG_VQA/ScienceQA/images \
+  --out /data/zhuxy/multimodal_deepresearch/output/scienceqa_report.json \
+  --details-out /data/zhuxy/multimodal_deepresearch/output/scienceqa_details.jsonl \
+  --details-format jsonl
+```
+
+## 数据集题目难度评估（AOKVQA / MMMU_Pro / M3CoT 风格整合）
+
+已将“题目难度评估”整合进 `eval_vqa.py`，并新增 `difficulty.py` 统一计算以下维度：
+
+- `linguistic_complexity`：问题文本复杂度
+- `reasoning_complexity`：多跳/链式推理复杂度
+- `multimodal_complexity`：图像/表格/图表带来的复杂度
+- `knowledge_intensity`：外部知识与文档依赖强度
+- `choice_ambiguity`：选项歧义度（适配多选题）
+- `retrieval_hardness`：lexical-graph 检索难度（DeepResearch 可评估部分）
+- `deepresearch_coverage`：DeepResearch 检索覆盖度（DeepResearch 可评估部分）
+
+并输出：
+- 综合难度分 `overall`
+- 难度分桶指标（easy/medium/hard）下的 baseline vs graph-enhanced EM/F1
+- 全量难度维度均值（用于最终报告）
+
+> 说明：你提供的 3 个 chatgpt.com/codex/tasks 链接在当前环境返回 403，无法直接读取原页面内容；本实现采用与这类评测常见流程一致的可复现统一框架，并预留字段（如 `reasoning_hops`/`cot_steps`/`choices`/`domain`）用于与具体数据集标注对齐。
+
+
+## 一键启动脚本（bash xxx.sh）
+
+已提供统一脚本：`run_deepresearch.sh`，可直接使用：
+
+```bash
+bash run_deepresearch.sh --help
+```
+
+### 1) 使用 DashScope API 调用（Qwen3-VL）
+
+```bash
+export DASHSCOPE_API_KEY="sk-xxxx"
+bash run_deepresearch.sh dashscope "比较 Qwen3-VL 与其他模型在文档理解上的差异"
+```
+
+脚本会自动设置：
+- `OPENAI_BASE_URL=https://dashscope.aliyuncs.com/compatible-mode/v1`
+- `OPENAI_API_KEY=$DASHSCOPE_API_KEY`
+- `MODEL_NAME=${MODEL_NAME:-Qwen/Qwen3-VL-8B-Instruct}`
+
+### 2) 本地 vLLM（两张 3090，默认 8/9）部署并运行
+
+先启动 vLLM OpenAI 服务：
+
+```bash
+bash run_deepresearch.sh vllm-start-8b /path/to/Qwen3-VL-8B-Instruct
+```
+
+默认参数：
+- `CUDA_VISIBLE_DEVICES_8B=8,9`
+- `VLLM_TP_SIZE_8B=2`
+- `model_path` 优先使用命令行参数；未传时回退到 `MODEL_NAME_8B`
+- `VLLM_PORT=8000`
+
+再在另一个终端运行 DeepResearch 查询：
+
+```bash
+bash run_deepresearch.sh vllm-run-8b "帮我总结多模态文档理解路线" /path/to/Qwen3-VL-8B-Instruct
+```
+
+### 3) 运行评测
+
+```bash
+bash run_deepresearch.sh eval --dataset /path/to/dataset.json --out /path/to/report.json --mock
+```
+
+
+### 2.1) 使用 Qwen3-VL-8B-Instruct 在两张卡（默认 8,9）TP 部署（唯一保留的本地部署方案）
+
+脚本已内置 8B 快捷模式：
+
+```bash
+# 默认模型 Qwen/Qwen3-VL-8B-Instruct，默认 GPU=8,9，TP=2
+bash run_deepresearch.sh vllm-start-8b
+
+# 或指定本地权重路径
+bash run_deepresearch.sh vllm-start-8b /data/models/Qwen3-VL-8B-Instruct
+
+# 在另一个终端发起查询
+bash run_deepresearch.sh vllm-run-8b "请分析这组图文问答样例"
+```
+
+可选环境变量：
+- `CUDA_VISIBLE_DEVICES_8B`（默认 `8,9`）
+- `VLLM_TP_SIZE_8B`（默认 `2`）
+- `MODEL_NAME_8B`（默认 `Qwen/Qwen3-VL-8B-Instruct`）
+
+
+稳定性说明（针对你遇到的 `Connection reset by peer`）：
+- 评测时本地图片不再使用 `file://` 直接传给模型，而是转换为 `data:image/...;base64,...` 再发送，降低 vLLM 侧解析/访问异常概率。
+- `models.py` 增加了 API 连接重试与超时配置（`API_TIMEOUT_S`、`API_RETRIES`、`API_RETRY_BACKOFF_S`）。
+- `eval_vqa.py` 现在对单条样本调用异常做了容错，不会整批任务直接中断，报告里会记录 `baseline_error` / `graph_error`。

--- a/deepresearch_qwen3_vl/VQA样例运行与评估报告说明.md
+++ b/deepresearch_qwen3_vl/VQA样例运行与评估报告说明.md
@@ -1,0 +1,128 @@
+# VQA 问答对在 DeepResearch 内的运行示例与评估报告说明
+
+本文用一个简化示例说明：
+
+1. 单条 VQA 样本如何在 `eval_vqa.py` 中被处理；
+2. 为什么会得到 baseline / graph 两套结果；
+3. 报告中的关键字段如何解读。
+
+---
+
+## 1) 示例输入（概念化）
+
+假设样本（MMMU/M3COT/A-OKVQA 归一化后）为：
+
+- `question`: 图中哪个选项正确？
+- `choices`: [A, B, C, D]
+- `answer`: C（在归一化后会映射成选项文本）
+- `documents`: 一组辅助文本
+- `image`: 一张图片（可能是路径、URL 或 bytes）
+
+程序内部会生成统一 sample，确保后续流程不依赖原始数据源字段差异。
+
+---
+
+## 2) 单题运行路径
+
+### Step A: 图像解析
+
+`resolve_image_reference()` 会按顺序尝试：
+
+1. `image_url`
+2. `__image_bytes`
+3. `image_path/image/img_path` + `--image-root`
+
+成功后得到可发送给多模态接口的 `image_ref`（常为 data URL）。
+
+### Step B: 构造两类上下文
+
+- **baseline_context**：直接拼接原始文档前几条
+- **graph_context**：用 lexical graph 检索后拼接命中片段
+
+这就是为什么评估会有两条预测链路：baseline vs graph。
+
+### Step C: 两次推理
+
+对同一问题会调用两次 `answer_with_context()`：
+
+1. `baseline_pred`
+2. `graph_pred`
+
+若任一次异常，会记录到 `baseline_error` / `graph_error`，同时该次预测置空字符串，流程继续。
+
+### Step D: 评分
+
+- 精确匹配：`baseline_exact` / `graph_exact`
+- 字符级 F1：`baseline_f1` / `graph_f1`
+- 难度分项：`difficulty.*`
+
+并记录样本追踪键 `sample_key`，用于断点续跑去重。
+
+---
+
+## 3) 报告中关键字段解释
+
+### 3.1 全局指标
+
+- `baseline_exact`, `graph_exact`：整体准确率
+- `baseline_f1`, `graph_f1`：整体 F1
+- `baseline_error_rate`, `graph_error_rate`：调用异常比例
+
+### 3.2 难度指标
+
+- `difficulty_scores.overall`：难度均值
+- `difficulty_scores.*`：各分项均值
+- `difficulty_bucket_thresholds.q33/q67`：三等分分位数阈值
+
+### 3.3 分桶指标
+
+`metrics_by_difficulty_bucket` 中按 `easy/medium/hard` 分组统计：
+
+- 样本数 `count`
+- 两条链路准确率/F1
+- 桶内平均难度 `avg_difficulty`
+
+---
+
+## 4) 断点续跑示例
+
+首次运行：
+
+```bash
+python eval_vqa.py data.jsonl \
+  --details-out details.jsonl \
+  --details-format jsonl \
+  --save-every 100
+```
+
+中断后恢复：
+
+```bash
+python eval_vqa.py data.jsonl \
+  --details-out details_resume.jsonl \
+  --details-format jsonl \
+  --resume-from details.jsonl
+```
+
+恢复时会读取已有 `sample_key` 并跳过已完成样本。
+
+---
+
+## 5) 常见现象说明
+
+1. **有些题 200，有些题 400/500**
+   - 多见于图像输入异常或服务侧资源波动；
+   - 评估脚本不会崩，会把错误写入 `*_error` 字段。
+
+2. **baseline 和 graph 同时报错**
+   - 常见于服务端当前不可用或该样本图像请求体有问题；
+   - 因为同一题会发两次请求，所以两条链路可能同时失败。
+
+3. **难度桶分布不固定**
+   - 当前是按当次数据分布的 q33/q67 动态分桶，不是固定阈值。
+
+---
+
+## 6) 小结
+
+通过统一归一化 + 双上下文推理 + 分位数分桶 + 可恢复执行，项目可以在多数据集场景下稳定地产生可分析、可追踪的 VQA 评估报告。

--- a/deepresearch_qwen3_vl/agents.py
+++ b/deepresearch_qwen3_vl/agents.py
@@ -1,0 +1,320 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+
+from config import settings
+from models import QwenVLClient
+from tools import ToolObservation, ToolRouter
+
+
+@dataclass
+class Evidence:
+    source: str
+    claim: str
+    excerpt: str
+    confidence: float
+
+
+@dataclass
+class SubQuestion:
+    question: str
+    intent: str
+    priority: int
+
+
+@dataclass
+class CritiqueResult:
+    sufficient: bool
+    follow_up_questions: list[str] = field(default_factory=list)
+    missing_dimensions: list[str] = field(default_factory=list)
+
+
+@dataclass
+class ResearchState:
+    question: str
+    sub_questions: list[SubQuestion] = field(default_factory=list)
+    evidence: list[Evidence] = field(default_factory=list)
+    tool_logs: list[ToolObservation] = field(default_factory=list)
+
+
+class PlannerAgent:
+    def __init__(self, llm: QwenVLClient) -> None:
+        self.llm = llm
+
+    def plan(self, question: str) -> list[SubQuestion]:
+        prompt = (
+            "将主问题拆解为3-6个子问题，并给每个子问题标注 intent 和 priority。"
+            "输出JSON数组，元素格式："
+            '{"question":"...","intent":"背景/对比/证据/反例/趋势","priority":1}。'
+        )
+        data = self.llm.chat_json(
+            [
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": question},
+            ],
+            fallback=[],
+        )
+
+        sub_questions: list[SubQuestion] = []
+        if isinstance(data, list):
+            for item in data:
+                if not isinstance(item, dict):
+                    continue
+                q = str(item.get("question", "")).strip()
+                if not q:
+                    continue
+                sub_questions.append(
+                    SubQuestion(
+                        question=q,
+                        intent=str(item.get("intent", "evidence")),
+                        priority=int(item.get("priority", 3)),
+                    )
+                )
+        if not sub_questions:
+            sub_questions = [SubQuestion(question=question, intent="evidence", priority=1)]
+        return sorted(sub_questions, key=lambda x: x.priority)
+
+
+class ResearcherAgent:
+    """Iterative agent that decides tool actions in ReAct-like JSON steps."""
+
+    def __init__(self, llm: QwenVLClient, tool_router: ToolRouter) -> None:
+        self.llm = llm
+        self.tool_router = tool_router
+
+    def _next_action(self, main_question: str, sub_question: SubQuestion, logs: list[ToolObservation]) -> dict:
+        tool_history = "\n\n".join(
+            [f"{idx+1}. {log.tool_name} 输入={log.input_data} 输出={log.output_data[:500]}" for idx, log in enumerate(logs)]
+        )
+        prompt = (
+            "你是研究执行Agent。你必须从以下工具中选择一个行动：\n"
+            "1) search_web {query, top_k}\n"
+            "2) open_webpage {url}\n"
+            "3) extract_images {url}\n"
+            "4) analyze_image {image_url, question}\n"
+            "5) ocr_image {image_url}\n"
+            "6) retrieve_lexical_graph {question, documents, top_k}\n"
+            "7) retrieve_graph_evidence {question, schema, graph_context}\n"
+            "8) finish {note}\n"
+            "仅输出JSON对象，格式："
+            '{"tool":"search_web","args":{...},"reason":"..."}'
+        )
+        return self.llm.chat_json(
+            [
+                {"role": "system", "content": prompt},
+                {
+                    "role": "user",
+                    "content": (
+                        f"主问题: {main_question}\n"
+                        f"当前子问题: {sub_question.question}\n"
+                        f"子问题意图: {sub_question.intent}\n"
+                        f"已有工具观察:\n{tool_history or '无'}"
+                    ),
+                },
+            ],
+            fallback={"tool": "search_web", "args": {"query": sub_question.question, "top_k": 5}, "reason": "fallback"},
+        )
+
+    def _distill_evidence(self, main_question: str, sub_question: str, logs: list[ToolObservation]) -> list[Evidence]:
+        compact_logs = "\n\n".join(
+            [f"工具={log.tool_name}\n输入={log.input_data}\n输出={log.output_data[:1200]}" for log in logs]
+        )
+        prompt = (
+            "从工具观察中提炼证据。输出JSON数组，元素格式："
+            '{"source":"来源URL或标识","claim":"证据支持的陈述","excerpt":"关键摘录","confidence":0.0-1.0}。'
+            "要求：最多4条，避免重复。"
+        )
+        data = self.llm.chat_json(
+            [
+                {"role": "system", "content": prompt},
+                {
+                    "role": "user",
+                    "content": f"主问题: {main_question}\n子问题: {sub_question}\n观察:\n{compact_logs}",
+                },
+            ],
+            fallback=[],
+        )
+
+        evidence: list[Evidence] = []
+        if isinstance(data, list):
+            for item in data:
+                if not isinstance(item, dict):
+                    continue
+                claim = str(item.get("claim", "")).strip()
+                if not claim:
+                    continue
+                confidence = float(item.get("confidence", 0.5))
+                confidence = max(0.0, min(1.0, confidence))
+                evidence.append(
+                    Evidence(
+                        source=str(item.get("source", "unknown")),
+                        claim=claim,
+                        excerpt=str(item.get("excerpt", "")),
+                        confidence=confidence,
+                    )
+                )
+        return evidence[:4]
+
+    def investigate(self, main_question: str, sub_question: SubQuestion) -> tuple[list[Evidence], list[ToolObservation]]:
+        logs: list[ToolObservation] = []
+
+        for _ in range(settings.max_actions_per_question):
+            action = self._next_action(main_question=main_question, sub_question=sub_question, logs=logs)
+            tool_name = str(action.get("tool", "finish"))
+            args = action.get("args", {}) if isinstance(action.get("args"), dict) else {}
+
+            if tool_name == "finish":
+                break
+
+            try:
+                obs = self.tool_router.run(tool_name=tool_name, args=args)
+            except Exception as exc:
+                obs = ToolObservation(
+                    tool_name=tool_name,
+                    input_data=args,
+                    output_data=f"TOOL_ERROR: {exc}",
+                )
+            logs.append(obs)
+
+        # Lexical-graph style enhancement: traverse cross-document evidence for the sub-question.
+        docs: list[dict] = []
+        for lg in logs:
+            if lg.tool_name == "open_webpage":
+                url = str(lg.input_data.get("url", "unknown"))
+                if lg.output_data:
+                    docs.append({"source": url, "text": lg.output_data})
+        if docs:
+            try:
+                graph_obs = self.tool_router.run(
+                    tool_name="retrieve_lexical_graph",
+                    args={"question": sub_question.question, "documents": docs, "top_k": 3},
+                )
+                logs.append(graph_obs)
+            except Exception as exc:
+                logs.append(
+                    ToolObservation(
+                        tool_name="retrieve_lexical_graph",
+                        input_data={"question": sub_question.question},
+                        output_data=f"TOOL_ERROR: {exc}",
+                    )
+                )
+
+            try:
+                graph_context = "\n".join([f"[{d['source']}] {d['text'][:300]}" for d in docs[:3]])
+                kg_obs = self.tool_router.run(
+                    tool_name="retrieve_graph_evidence",
+                    args={
+                        "question": sub_question.question,
+                        "schema": {
+                            "summary": f"Question-driven proxy schema for: {main_question}",
+                            "node_types": ["Entity", "ImageObject", "OCRText"],
+                            "relation_types": ["mentions", "depicts", "located_in", "related_to", "supports"],
+                        },
+                        "graph_context": graph_context,
+                    },
+                )
+                logs.append(kg_obs)
+            except Exception as exc:
+                logs.append(
+                    ToolObservation(
+                        tool_name="retrieve_graph_evidence",
+                        input_data={"question": sub_question.question},
+                        output_data=f"TOOL_ERROR: {exc}",
+                    )
+                )
+
+        evidence = self._distill_evidence(main_question=main_question, sub_question=sub_question.question, logs=logs)
+        return evidence, logs
+
+
+class CriticAgent:
+    def __init__(self, llm: QwenVLClient) -> None:
+        self.llm = llm
+
+    def critique(self, question: str, evidence: list[Evidence]) -> CritiqueResult:
+        evidence_brief = "\n\n".join(
+            [
+                f"来源: {e.source}\n结论: {e.claim}\n摘录: {e.excerpt[:300]}\n置信度: {e.confidence}"
+                for e in evidence[:12]
+            ]
+        )
+        prompt = (
+            "判断当前证据是否足够回答主问题。输出JSON对象："
+            '{"sufficient":true/false,"follow_up_questions":[...],"missing_dimensions":[...]}。'
+        )
+        data = self.llm.chat_json(
+            [
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": f"问题: {question}\n\n证据:\n{evidence_brief}"},
+            ],
+            fallback={"sufficient": False, "follow_up_questions": [question], "missing_dimensions": ["fallback"]},
+        )
+
+        return CritiqueResult(
+            sufficient=bool(data.get("sufficient", False)),
+            follow_up_questions=[str(x) for x in data.get("follow_up_questions", [])][:3],
+            missing_dimensions=[str(x) for x in data.get("missing_dimensions", [])][:4],
+        )
+
+
+class VerifierAgent:
+    def __init__(self, llm: QwenVLClient) -> None:
+        self.llm = llm
+
+    def verify(self, question: str, evidence: list[Evidence]) -> list[Evidence]:
+        """Basic evidence pruning to reduce hallucinated or weak claims."""
+        packed = "\n\n".join(
+            [
+                f"[{idx}] 来源={e.source}\n陈述={e.claim}\n摘录={e.excerpt[:250]}\n置信度={e.confidence}"
+                for idx, e in enumerate(evidence)
+            ]
+        )
+        prompt = (
+            "对每条证据进行有效性筛选。返回JSON数组，元素为应保留的索引（整数）。"
+            "标准：与主问题相关、有来源、有可验证摘录。"
+        )
+        data = self.llm.chat_json(
+            [
+                {"role": "system", "content": prompt},
+                {"role": "user", "content": f"主问题: {question}\n\n证据候选:\n{packed}"},
+            ],
+            fallback=list(range(min(len(evidence), 6))),
+        )
+
+        if not isinstance(data, list):
+            return evidence[:6]
+
+        keep: list[Evidence] = []
+        for idx in data:
+            if isinstance(idx, int) and 0 <= idx < len(evidence):
+                keep.append(evidence[idx])
+        return keep[:10] if keep else evidence[:6]
+
+
+class SynthesizerAgent:
+    def __init__(self, llm: QwenVLClient) -> None:
+        self.llm = llm
+
+    def synthesize(self, state: ResearchState) -> str:
+        evidence_text = "\n\n".join(
+            [
+                f"来源: {e.source}\n陈述: {e.claim}\n摘录: {e.excerpt[:300]}\n置信度: {e.confidence}"
+                for e in state.evidence[:12]
+            ]
+        )
+        prompt = (
+            "你是深度研究报告撰写Agent。输出结构化中文报告：\n"
+            "1) 执行摘要\n2) 分析框架\n3) 关键证据（按来源编号）\n"
+            "4) 结论与适用边界\n5) 风险与不确定性\n6) 后续研究建议。\n"
+            "必须引用提供的证据，不得凭空编造。"
+        )
+        return self.llm.chat(
+            [
+                {"role": "system", "content": prompt},
+                {
+                    "role": "user",
+                    "content": f"主问题: {state.question}\n\n证据库:\n{evidence_text}",
+                },
+            ],
+            temperature=0.1,
+        )

--- a/deepresearch_qwen3_vl/byokg_rag.py
+++ b/deepresearch_qwen3_vl/byokg_rag.py
@@ -1,0 +1,365 @@
+from __future__ import annotations
+
+import json
+import re
+from dataclasses import dataclass
+from typing import Any, Callable
+
+
+def _uniq(seq: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for x in seq:
+        s = str(x).strip()
+        if not s or s in seen:
+            continue
+        seen.add(s)
+        out.append(s)
+    return out
+
+
+def _is_noise_entity(v: str) -> bool:
+    s = v.strip()
+    if not s:
+        return True
+    if len(s) <= 1:
+        return True
+    if re.fullmatch(r"[\W_]+", s):
+        return True
+    return False
+
+
+@dataclass
+class RerankerConfig:
+    hop_l: int
+    top_k: int
+
+
+@dataclass
+class StrategyResult:
+    strategy: str
+    entities: list[str]
+    paths: list[dict[str, Any]]
+    dsl: dict[str, Any]
+    score: float
+
+
+class CypherDSLCompiler:
+    """Compile schema-constrained DSL JSON to OpenCypher."""
+
+    def compile(self, dsl: dict[str, Any]) -> str:
+        match_parts: list[str] = []
+
+        for node in dsl.get("match", []):
+            alias = str(node.get("alias", "n")).strip() or "n"
+            ntype = str(node.get("node_type", "")).strip()
+            cons = node.get("constraints", {}) or {}
+            where_props = []
+            for k, v in cons.items():
+                if isinstance(v, str):
+                    where_props.append(f"{alias}.{k} = '{v.replace(chr(39), chr(92)+chr(39))}'")
+                else:
+                    where_props.append(f"{alias}.{k} = {json.dumps(v)}")
+            label = f":{ntype}" if ntype else ""
+            match_parts.append(f"({alias}{label})")
+            node["__where_props"] = where_props
+
+        edge_parts: list[str] = []
+        for e in dsl.get("edges", []):
+            frm = str(e.get("from", "")).strip()
+            to = str(e.get("to", "")).strip()
+            rel = str(e.get("rel_type", "")).strip()
+            if not frm or not to:
+                continue
+            edge_parts.append(f"({frm})-[:{rel}]->({to})" if rel else f"({frm})--({to})")
+
+        query_parts: list[str] = []
+        if edge_parts:
+            query_parts.append("MATCH " + ", ".join(edge_parts))
+        elif match_parts:
+            query_parts.append("MATCH " + ", ".join(match_parts))
+        else:
+            query_parts.append("MATCH (n)")
+
+        where_clauses: list[str] = []
+        for node in dsl.get("match", []):
+            where_clauses.extend(node.get("__where_props", []))
+        for cond in dsl.get("where", []) or []:
+            if isinstance(cond, str) and cond.strip():
+                where_clauses.append(cond.strip())
+        if where_clauses:
+            query_parts.append("WHERE " + " AND ".join(where_clauses))
+
+        returns = dsl.get("return", ["n"])
+        if not isinstance(returns, list) or not returns:
+            returns = ["n"]
+        query_parts.append("RETURN " + ", ".join(str(x) for x in returns))
+
+        sort = dsl.get("sort")
+        if isinstance(sort, str) and sort.strip():
+            query_parts.append("ORDER BY " + sort.strip())
+
+        limit = dsl.get("limit")
+        if isinstance(limit, int) and limit > 0:
+            query_parts.append(f"LIMIT {limit}")
+
+        return "\n".join(query_parts)
+
+
+class BYOKGValidator:
+    def __init__(self, dry_run: Callable[[str], bool] | None = None) -> None:
+        self.dry_run = dry_run
+
+    def validate(self, artifacts: dict[str, Any], schema: dict[str, Any]) -> tuple[bool, list[str]]:
+        errors: list[str] = []
+
+        entities = [str(x) for x in artifacts.get("entities", [])]
+        entities = [x for x in _uniq(entities) if not _is_noise_entity(x)]
+        artifacts["entities"] = entities
+        if not entities:
+            errors.append("entities_empty")
+
+        allowed_rels = {str(x) for x in schema.get("relation_types", [])} if isinstance(schema, dict) else set()
+        paths = artifacts.get("paths", [])
+        if isinstance(paths, list):
+            for p in paths:
+                if not isinstance(p, dict):
+                    continue
+                rel = str(p.get("relation", "")).strip()
+                if rel and allowed_rels and rel not in allowed_rels:
+                    errors.append(f"invalid_relation:{rel}")
+
+        cypher = str(artifacts.get("opencypher", "")).strip()
+        if cypher:
+            c_up = cypher.upper()
+            if "MATCH" not in c_up or "RETURN" not in c_up:
+                errors.append("cypher_missing_match_or_return")
+            if self.dry_run is not None:
+                try:
+                    if not self.dry_run(cypher + "\nLIMIT 1"):
+                        errors.append("cypher_dry_run_failed")
+                except Exception:
+                    errors.append("cypher_dry_run_failed")
+        else:
+            errors.append("cypher_empty")
+
+        return (len(errors) == 0), errors
+
+
+class BYOKGRAGProvider:
+    """Graph Evidence Provider adapted from BYOKG-RAG style multi-strategy refinement."""
+
+    def __init__(
+        self,
+        linker: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        strategy_linker: Callable[[dict[str, Any]], dict[str, Any]] | None = None,
+        cypher_dry_run: Callable[[str], bool] | None = None,
+        cypher_executor: Callable[[str], list[dict[str, Any]]] | None = None,
+        max_refine_rounds: int = 2,
+        max_query_results: int = 20,
+    ) -> None:
+        self.linker = linker
+        self.strategy_linker = strategy_linker
+        self.max_refine_rounds = max_refine_rounds
+        self.max_query_results = max_query_results
+        self.validator = BYOKGValidator(dry_run=cypher_dry_run)
+        self.cypher_executor = cypher_executor
+        self.compiler = CypherDSLCompiler()
+
+    def _dynamic_reranker(self, question: str, schema: dict[str, Any]) -> RerankerConfig:
+        rels = schema.get("relation_types", []) if isinstance(schema, dict) else []
+        dense = len(rels) > 80
+        multi_hop = any(k in question.lower() for k in ["then", "after", "before", "compare", "path", "multi-hop", "并且", "再", "然后"])
+
+        l = 1 if dense else 2
+        k = 10 if dense else 30
+        if multi_hop:
+            k = min(k + 20, 80)
+        return RerankerConfig(hop_l=l, top_k=k)
+
+    def _default_linker(self, payload: dict[str, Any]) -> dict[str, Any]:
+        question = str(payload.get("question", ""))
+        tokens = [t.strip("?,.()[]{}") for t in question.split()]
+        entities = [t for t in tokens if len(t) > 2][:4]
+        dsl = {
+            "match": [{"node_type": "Entity", "alias": "e", "constraints": {"name": entities[0] if entities else ""}}],
+            "return": ["e"],
+            "limit": 20,
+        }
+        return {
+            "entities": entities,
+            "paths": [],
+            "dsl": dsl,
+        }
+
+    def _invoke_linker(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if self.linker is not None:
+            out = self.linker(payload)
+            return out if isinstance(out, dict) else {}
+        return self._default_linker(payload)
+
+    def _invoke_strategy_linker(self, payload: dict[str, Any]) -> dict[str, Any]:
+        if self.strategy_linker is not None:
+            out = self.strategy_linker(payload)
+            return out if isinstance(out, dict) else {}
+        return self._invoke_linker(payload)
+
+    def _strategy_payloads(self, payload: dict[str, Any]) -> list[dict[str, Any]]:
+        schema = payload.get("schema", {}) if isinstance(payload.get("schema"), dict) else {}
+        return [
+            {**payload, "strategy": "entity_path", "hints": ["entity-first", "path-expand"]},
+            {**payload, "strategy": "relation_path", "hints": ["relation-first", "schema-filter"], "focus_relations": schema.get("relation_types", [])[:20]},
+            {**payload, "strategy": "query_shape", "hints": ["query-structure", "answer-type"]},
+        ]
+
+    def _score_strategy_result(self, entities: list[str], paths: list[dict[str, Any]], schema: dict[str, Any]) -> float:
+        allowed_rels = {str(x) for x in schema.get("relation_types", [])} if isinstance(schema, dict) else set()
+        valid_paths = 0
+        for p in paths:
+            if not isinstance(p, dict):
+                continue
+            rel = str(p.get("relation", "")).strip()
+            if (not allowed_rels) or (rel in allowed_rels):
+                valid_paths += 1
+        entity_term = min(len(entities), 6) / 6.0
+        path_term = min(valid_paths, 10) / 10.0
+        return _clip_float(0.55 * entity_term + 0.45 * path_term)
+
+    def _ensemble_linking(self, payload: dict[str, Any], schema: dict[str, Any]) -> tuple[dict[str, Any], list[dict[str, Any]]]:
+        candidates: list[StrategyResult] = []
+        for p in self._strategy_payloads(payload):
+            linked = self._invoke_strategy_linker(p)
+            entities = _uniq([str(x) for x in linked.get("entities", [])])
+            paths = linked.get("paths", []) if isinstance(linked.get("paths"), list) else []
+            dsl = linked.get("dsl", {}) if isinstance(linked.get("dsl"), dict) else {}
+            score = self._score_strategy_result(entities, paths, schema)
+            candidates.append(StrategyResult(strategy=str(p.get("strategy", "default")), entities=entities, paths=paths, dsl=dsl, score=score))
+
+        if not candidates:
+            fallback = self._invoke_linker(payload)
+            return fallback, []
+
+        candidates.sort(key=lambda x: x.score, reverse=True)
+        best = candidates[0]
+        merged_entities = _uniq([e for c in candidates[:2] for e in c.entities])
+        merged_paths = [p for c in candidates[:2] for p in c.paths if isinstance(p, dict)]
+        best_artifact = {
+            "entities": merged_entities,
+            "paths": merged_paths,
+            "dsl": best.dsl,
+            "linking_strategy": best.strategy,
+        }
+        ranking = [{"strategy": c.strategy, "score": c.score, "entities": len(c.entities), "paths": len(c.paths)} for c in candidates]
+        return best_artifact, ranking
+
+    def _expand_schema_focus(self, question: str, schema: dict[str, Any]) -> dict[str, Any]:
+        rels = [str(x) for x in schema.get("relation_types", [])] if isinstance(schema, dict) else []
+        q_tokens = set(t.lower() for t in re.split(r"\W+", question) if t)
+        focus_rels = [r for r in rels if any(t and t in r.lower() for t in q_tokens)]
+        if not focus_rels:
+            focus_rels = rels[:15]
+        return {
+            **schema,
+            "focus_relation_types": focus_rels[:25],
+            "schema_pruned": True,
+        }
+
+    def _run_query(self, cypher: str) -> list[dict[str, Any]]:
+        if self.cypher_executor is None or not cypher:
+            return []
+        try:
+            rows = self.cypher_executor(cypher)
+        except Exception:
+            return []
+        if not isinstance(rows, list):
+            return []
+        out = [r for r in rows if isinstance(r, dict)]
+        return out[: self.max_query_results]
+
+    def retrieve_graph_evidence(
+        self,
+        question: str,
+        schema: dict[str, Any],
+        graph_context: str | None = None,
+    ) -> dict[str, Any]:
+        reranker = self._dynamic_reranker(question, schema)
+        artifacts: dict[str, Any] = {"entities": [], "paths": [], "dsl": {}, "opencypher": ""}
+        history: list[dict[str, Any]] = []
+
+        payload = {
+            "question": question,
+            "schema": self._expand_schema_focus(question, schema),
+            "graph_context": graph_context or "",
+            "mode": "full",
+            "reranker": {"L": reranker.hop_l, "k": reranker.top_k},
+        }
+        strategy_ranking: list[dict[str, Any]] = []
+
+        for i in range(max(self.max_refine_rounds, 1)):
+            linked, strategy_ranking = self._ensemble_linking(payload, schema)
+            artifacts.update({k: v for k, v in linked.items() if k in {"entities", "paths", "dsl", "opencypher"}})
+
+            if not artifacts.get("opencypher") and isinstance(artifacts.get("dsl"), dict):
+                try:
+                    artifacts["opencypher"] = self.compiler.compile(artifacts["dsl"])
+                except Exception:
+                    artifacts["opencypher"] = ""
+
+            ok, errors = self.validator.validate(artifacts, schema)
+            history.append({"round": i + 1, "ok": ok, "errors": errors})
+            if ok:
+                break
+
+            payload = {
+                "question": question,
+                "schema": {
+                    "summary": schema.get("summary", ""),
+                    "relation_types": schema.get("relation_types", []),
+                    "node_types": schema.get("node_types", []),
+                },
+                "graph_context": graph_context or "",
+                "previous_artifacts": artifacts,
+                "errors": errors,
+                "mode": "repair-only",
+                "allowed_patch_fields": ["entities", "paths", "dsl", "opencypher"],
+            }
+
+        entities = _uniq([str(x) for x in artifacts.get("entities", [])])
+        paths = artifacts.get("paths", []) if isinstance(artifacts.get("paths"), list) else []
+        cypher = str(artifacts.get("opencypher", "")).strip()
+        query_results = self._run_query(cypher)
+        image_evidence = [
+            row for row in query_results
+            if any(k in row for k in ["image", "image_url", "bbox", "ocr_text", "visual_object"])
+        ]
+
+        graph_evidence: dict[str, Any] = {
+            "triples": [p for p in paths if isinstance(p, dict)],
+            "paths": paths,
+            "query_results": query_results,
+            "image_evidence": image_evidence,
+        }
+        linking_artifacts = {
+            "entities": entities,
+            "paths": paths,
+            "opencypher": cypher,
+            "dsl": artifacts.get("dsl", {}),
+            "reranker": {"L": reranker.hop_l, "k": reranker.top_k},
+            "strategy_ranking": strategy_ranking,
+            "selected_strategy": linked.get("linking_strategy", "unknown") if isinstance(linked, dict) else "unknown",
+            "refinement_history": history,
+        }
+
+        coverage = _clip_float((len(entities) / 4.0) * 0.5 + (len(paths) / max(reranker.top_k, 1)) * 0.3 + (min(len(query_results), 5) / 5.0) * 0.2)
+        confidence = _clip_float(0.5 * coverage + (0.5 if cypher else 0.0))
+
+        return {
+            "graph_evidence": graph_evidence,
+            "linking_artifacts": linking_artifacts,
+            "confidence": confidence,
+            "coverage": coverage,
+        }
+
+
+def _clip_float(v: float, lo: float = 0.0, hi: float = 1.0) -> float:
+    return max(lo, min(hi, float(v)))

--- a/deepresearch_qwen3_vl/config.py
+++ b/deepresearch_qwen3_vl/config.py
@@ -1,0 +1,30 @@
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass
+class Settings:
+    """Runtime configuration for a DeepResearch-like Qwen3-VL framework."""
+
+    model_name: str = os.getenv("MODEL_NAME", "Qwen/Qwen3-VL-8B-Instruct")
+    api_base: str = os.getenv("OPENAI_BASE_URL", "http://localhost:8000/v1")
+    api_key: str = os.getenv("OPENAI_API_KEY", "EMPTY")
+
+    api_timeout_s: float = float(os.getenv("API_TIMEOUT_S", "120"))
+    api_retries: int = int(os.getenv("API_RETRIES", "3"))
+    api_retry_backoff_s: float = float(os.getenv("API_RETRY_BACKOFF_S", "2"))
+    api_max_tokens: int = int(os.getenv("API_MAX_TOKENS", "128"))
+
+    max_rounds: int = int(os.getenv("MAX_RESEARCH_ROUNDS", "3"))
+    max_snippets_per_round: int = int(os.getenv("MAX_SNIPPETS_PER_ROUND", "5"))
+    max_actions_per_question: int = int(os.getenv("MAX_ACTIONS_PER_QUESTION", "4"))
+    max_evidence_items: int = int(os.getenv("MAX_EVIDENCE_ITEMS", "12"))
+    max_tool_logs: int = int(os.getenv("MAX_TOOL_LOGS", "20"))
+
+    search_api_url: str | None = os.getenv("SEARCH_API_URL")
+    search_api_key: str | None = os.getenv("SEARCH_API_KEY")
+
+
+settings = Settings()

--- a/deepresearch_qwen3_vl/difficulty.py
+++ b/deepresearch_qwen3_vl/difficulty.py
@@ -1,0 +1,708 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from statistics import mean
+from typing import Any
+
+from lexical_graph import LexicalGraphRetriever, build_graph_from_corpus
+
+
+@dataclass
+class DifficultyBreakdown:
+    overall: float
+    linguistic_complexity: float
+    reasoning_complexity: float
+    multimodal_complexity: float
+    knowledge_intensity: float
+    choice_ambiguity: float
+    retrieval_hardness: float
+    deepresearch_coverage: float
+
+
+def _qnorm_100(v: float) -> float:
+    return _clip(v) * 100.0
+
+
+def _norm_linear(v: float, lo: float, hi: float) -> float:
+    if hi <= lo:
+        return 0.0
+    return _clip((v - lo) / (hi - lo))
+
+
+def _norm_q(v: float, q: float = 0.7) -> float:
+    return _clip(_clip(v) ** max(q, 1e-6))
+
+
+def _task_family(sample: dict[str, Any]) -> str:
+    dataset_type = str(sample.get("dataset_type", "generic")).lower()
+    if dataset_type in {"generic", "aokvqa", "a_okvqa", "okvqa", "fvqa", "krvqa", "cmmqa"}:
+        return "knowledge_enhanced_vqa"
+    return "ordinary_multimodal_vqa"
+
+
+def _clip(v: float, lo: float = 0.0, hi: float = 1.0) -> float:
+    return max(lo, min(hi, v))
+
+
+def _is_missing(v: Any) -> bool:
+    if v is None:
+        return True
+    try:
+        # handles numpy/pandas NaN scalars safely
+        return bool(v != v)
+    except Exception:
+        return False
+
+
+def _first_non_missing(*vals: Any, default: Any = None) -> Any:
+    for v in vals:
+        if not _is_missing(v):
+            return v
+    return default
+
+
+def _to_option_list(v: Any) -> list[Any]:
+    if _is_missing(v):
+        return []
+    if hasattr(v, "tolist"):
+        try:
+            v = v.tolist()
+        except Exception:
+            pass
+    if isinstance(v, (list, tuple)):
+        return list(v)
+    return []
+
+
+def _reasoning_chain_paths(sample: dict[str, Any]) -> list[list[Any]]:
+    rc = sample.get("reasoning_chains")
+    if isinstance(rc, list):
+        out: list[list[Any]] = []
+        for item in rc:
+            if isinstance(item, (list, tuple)) and len(item) >= 3:
+                out.append(list(item))
+        if out:
+            return out
+    docs = sample.get("documents", [])
+    if isinstance(docs, list):
+        for d in docs:
+            if isinstance(d, dict) and str(d.get("source", "")) == "reasoning_chains":
+                txt = str(d.get("text", ""))
+                lines = [ln.strip() for ln in txt.splitlines() if ln.strip()]
+                out = []
+                for ln in lines:
+                    if "--" in ln and "-->" in ln:
+                        out.append([ln])
+                if out:
+                    return out
+    return []
+
+
+def _operator_profile(question: str, docs: Any) -> dict[str, float]:
+    q = question.lower()
+    ops = {
+        "relate": sum(1 for k in ["related", "relation", "belong", "connected", "where", "which"] if k in q),
+        "filter": sum(1 for k in ["except", "not", "without", "only", "at least", "at most"] if k in q),
+        "andor": sum(1 for k in [" and ", " or ", "both", "either"] if k in q),
+        "compare": sum(1 for k in ["more", "less", "than", "compare", "difference", "farthest", "nearest"] if k in q),
+        "count": sum(1 for k in ["how many", "count", "number of"] if k in q),
+    }
+    if isinstance(docs, list):
+        text = " ".join(str(d.get("text", "")).lower() for d in docs if isinstance(d, dict))
+        if " if " in text or " then " in text:
+            ops["andor"] += 1
+    return {k: float(v) for k, v in ops.items()}
+
+
+def _h_score(sample: dict[str, Any], reasoning_base: float) -> float:
+    chains = _reasoning_chain_paths(sample)
+    if chains:
+        d_min = float(max(min(len(chains), 3), 1))
+        return _norm_linear(d_min, 1.0, 3.0)
+
+    dist_proxy = _to_float(_first_non_missing(sample.get("reasoning_hops"), sample.get("cot_steps"), sample.get("steps"), default=1), 1.0)
+    docs = sample.get("documents", [])
+    ls = 1.0
+    if isinstance(docs, list):
+        ls = max((str(d.get("text", "")).count("\n") + 1 for d in docs if isinstance(d, dict)), default=1)
+    h_raw = 0.6 * dist_proxy + 0.4 * ls
+    return _clip(0.6 * _norm_linear(h_raw, 1.0, 5.0) + 0.4 * reasoning_base)
+
+
+def _d_score(sample: dict[str, Any], ambiguity: float, retrieval_hardness: float, multimodal: float) -> float:
+    chains = _reasoning_chain_paths(sample)
+    if chains:
+        branch = {}
+        for c in chains:
+            if len(c) >= 3:
+                h = str(c[0]).strip().lower()
+                t = str(c[2]).strip().lower()
+                branch[h] = branch.get(h, 0) + 1
+                branch[t] = branch.get(t, 0) + 1
+        if branch:
+            deg_avg = sum(max(v - 1, 0) for v in branch.values()) / max(len(branch), 1)
+            return _norm_q(_norm_linear(deg_avg, 0.0, 4.0), q=0.8)
+
+    options = _to_option_list(_first_non_missing(sample.get("choices"), sample.get("options"), default=[]))
+    text = str(sample.get("question", "")).lower()
+    cand_proxy = len(options) + sum(1 for k in ["who", "which", "what", "where"] if k in text)
+    d_text = _norm_linear(cand_proxy - 1.0, 0.0, 10.0)
+    d_vis = _clip(multimodal)
+    return _clip(0.45 * d_text + 0.35 * ambiguity + 0.20 * max(retrieval_hardness, d_vis))
+
+
+def _o_score(sample: dict[str, Any], linguistic: float) -> float:
+    ops = _operator_profile(str(sample.get("question", "")), sample.get("documents", []))
+    weights = {"relate": 0.20, "filter": 0.20, "andor": 0.15, "compare": 0.25, "count": 0.20}
+    raw = sum(weights[k] * ops.get(k, 0.0) for k in weights)
+    op_complex = _norm_q(_norm_linear(raw, 0.0, 4.0), q=0.75)
+    return _clip(0.65 * op_complex + 0.35 * linguistic)
+
+
+def _a_score(multimodal: float, coverage: float, knowledge: float) -> float:
+    a_vis = _clip(multimodal)
+    a_cov = _clip(1.0 - coverage)
+    a_kg_dep = _clip(knowledge)
+    a_raw = 0.45 * a_vis + 0.30 * a_cov + 0.25 * a_kg_dep
+    return _norm_q(a_raw, q=0.85)
+
+
+def _combine_hdoa(sample: dict[str, Any], h: float, d: float, o: float, a: float) -> float:
+    fam = _task_family(sample)
+    if fam == "knowledge_enhanced_vqa":
+        w_h, w_d, w_o, w_a = 0.20, 0.25, 0.10, 0.35
+    else:
+        w_h, w_d, w_o, w_a = 0.30, 0.25, 0.15, 0.30
+    return _clip(w_h * h + w_d * d + w_o * o + w_a * a)
+
+
+def _has_image(sample: dict[str, Any]) -> tuple[bool, int]:
+    image_url = sample.get("image_url")
+    images = sample.get("images")
+    has_image = isinstance(image_url, str) and bool(image_url.strip())
+    image_count = 0
+    if isinstance(images, list):
+        image_count = len(images)
+        has_image = has_image or image_count > 0
+    elif hasattr(images, "tolist"):
+        try:
+            img_list = images.tolist()
+            if isinstance(img_list, list):
+                image_count = len(img_list)
+                has_image = has_image or image_count > 0
+        except Exception:
+            pass
+    if isinstance(sample.get("image"), str) and sample.get("image", "").strip():
+        has_image = True
+        image_count = max(image_count, 1)
+    if isinstance(sample.get("image_path"), str) and sample.get("image_path", "").strip():
+        has_image = True
+        image_count = max(image_count, 1)
+    if isinstance(sample.get("img_path"), str) and sample.get("img_path", "").strip():
+        has_image = True
+        image_count = max(image_count, 1)
+    if isinstance(sample.get("__image_bytes"), (bytes, bytearray)):
+        has_image = True
+        image_count = max(image_count, 1)
+    return has_image, image_count
+
+
+def _base_components(sample: dict[str, Any]) -> tuple[float, float, float, float, float, float, float]:
+    question = str(sample.get("question", ""))
+    q_len = len(question)
+    linguistic = _clip((q_len - 20) / 120)
+
+    reasoning_hints = _first_non_missing(
+        sample.get("reasoning_hops"), sample.get("cot_steps"), sample.get("steps"), default=1
+    )
+    try:
+        hops = float(reasoning_hints)
+    except Exception:
+        hops = 1.0
+    reasoning = _clip((hops - 1) / 5)
+
+    has_image, image_count = _has_image(sample)
+    table_flag = 1.0 if sample.get("has_table") else 0.0
+    chart_flag = 1.0 if sample.get("has_chart") else 0.0
+    multimodal = _clip(0.35 * (1 if has_image else 0) + 0.2 * min(image_count, 3) / 3 + 0.25 * table_flag + 0.2 * chart_flag)
+
+    docs = sample.get("documents", [])
+    doc_count = len(docs) if isinstance(docs, list) else 0
+    domain = str(sample.get("domain", "")).lower()
+    domain_bonus = 0.15 if domain in {"science", "medicine", "law", "finance", "engineering"} else 0.0
+    knowledge = _clip(min(doc_count, 8) / 8 + domain_bonus)
+
+    options = _to_option_list(_first_non_missing(sample.get("choices"), sample.get("options"), default=[]))
+    ambiguity = _clip((len(options) - 2) / 6) if options else 0.15
+
+    retrieval_hardness, coverage = _estimate_retrieval_hardness_and_coverage(question=question, docs=docs)
+    return linguistic, reasoning, multimodal, knowledge, ambiguity, retrieval_hardness, coverage
+
+
+def _to_float(v: Any, default: float = 0.0) -> float:
+    try:
+        return float(v)
+    except Exception:
+        return default
+
+
+def _to_token_list(text: str) -> list[str]:
+    return [t for t in text.strip().split() if t]
+
+
+def _detect_m3cot_question_type(question: str) -> str:
+    q = question.lower()
+    if any(k in q for k in ["how many", "数量", "几", "count"]):
+        return "count"
+    if any(k in q for k in ["why", "原因", "because", "推断", "infer"]):
+        return "reasoning"
+    if any(k in q for k in ["what color", "颜色", "where", "位置", "which"]):
+        return "attribute"
+    return "generic"
+
+
+def _m3cot_vision_score(sample: dict[str, Any]) -> float:
+    obj_count = _to_float(_first_non_missing(sample.get("object_count"), sample.get("num_objects"), default=0), 0.0)
+    occlusion = _to_float(sample.get("occlusion_ratio"), 0.0)
+    small_ratio = _to_float(sample.get("small_object_ratio"), 0.0)
+    ocr_chars = _to_float(_first_non_missing(sample.get("ocr_char_count"), sample.get("text_char_count"), default=0), 0.0)
+    ocr_area_ratio = _to_float(sample.get("ocr_area_ratio"), 0.0)
+
+    if obj_count <= 0:
+        # fallback: infer rough object complexity from image+caption/doc presence
+        has_image, _ = _has_image(sample)
+        obj_count = 4.0 if has_image else 0.0
+    if ocr_chars <= 0:
+        docs = sample.get("documents", [])
+        if isinstance(docs, list):
+            joined = " ".join(str(d.get("text", "")) for d in docs if isinstance(d, dict))
+            ocr_chars = min(len(joined), 120)
+
+    s_obj = _clip(min(obj_count, 20.0) / 20.0) * 100.0
+    s_occ = _clip(occlusion / 0.8) * 100.0
+    s_small = _clip(small_ratio / 0.5) * 100.0
+    s_text = _clip(min((ocr_area_ratio * 2.0) + (ocr_chars / 120.0), 1.0)) * 100.0
+    return _clip(mean([s_obj, s_occ, s_small, s_text]) / 100.0) * 100.0
+
+
+def _m3cot_question_score(sample: dict[str, Any]) -> float:
+    question = str(sample.get("question", ""))
+    tokens = _to_token_list(question)
+    q_len = len(tokens)
+    q_len_score = _clip(min(q_len, 30) / 30.0) * 100.0
+
+    pronouns = sum(1 for t in tokens if t.lower() in {"it", "this", "that", "these", "those", "they"})
+    pronoun_ratio = pronouns / max(q_len, 1)
+    s_amb = _clip(pronoun_ratio / 0.15) * 100.0
+
+    q_lower = question.lower()
+    op_hits = sum(1 for k in ["compare", "difference", "both", "and", "or", "if", "then", "more", "less"] if k in q_lower)
+    s_ops = _clip(op_hits / 4.0) * 100.0
+
+    span_hits = sum(1 for k in ["text", "number", "word", "table", "chart", "color", "shape", "位置", "数字"] if k in q_lower)
+    s_span = _clip(span_hits / 4.0) * 100.0
+    return _clip(mean([q_len_score, s_amb, s_ops, s_span]) / 100.0) * 100.0
+
+
+def _m3cot_reasoning_score(sample: dict[str, Any]) -> float:
+    question = str(sample.get("question", ""))
+    q_type = _detect_m3cot_question_type(question)
+    occlusion = _clip(_to_float(sample.get("occlusion_ratio"), 0.1) / 0.8) * 100.0
+    small_ratio = _clip(_to_float(sample.get("small_object_ratio"), 0.1) / 0.5) * 100.0
+    cluster = _clip(_to_float(_first_non_missing(sample.get("cluster_count"), sample.get("object_cluster_count"), default=1), 1.0) / 10.0) * 100.0
+
+    if q_type == "count":
+        return _clip((0.4 * occlusion + 0.3 * small_ratio + 0.3 * cluster) / 100.0) * 100.0
+    if q_type == "reasoning":
+        rationale = str(sample.get("rationale", ""))
+        steps = max(rationale.count("\n") + 1, 1) if rationale.strip() else 1
+        step_score = _clip((steps - 1) / 8.0) * 100.0
+        return _clip((0.5 * step_score + 0.3 * occlusion + 0.2 * cluster) / 100.0) * 100.0
+    return _clip((0.4 * cluster + 0.3 * occlusion + 0.3 * small_ratio) / 100.0) * 100.0
+
+
+def _m3cot_e_model_score(sample: dict[str, Any]) -> float:
+    # expected optional field from external baseline ensemble
+    arr = sample.get("model_errors")
+    if isinstance(arr, list) and arr:
+        vals = [_to_float(x, 0.0) for x in arr]
+        avg = sum(vals) / max(len(vals), 1)
+        # 1 means error, 0 means correct
+        return _clip(avg) * 100.0
+
+    baseline_correct = sample.get("baseline_correct")
+    if baseline_correct is not None:
+        try:
+            return (0.0 if bool(baseline_correct) else 100.0)
+        except Exception:
+            pass
+
+    # fallback proxy by choice ambiguity + retrieval hardness
+    options = _to_option_list(_first_non_missing(sample.get("choices"), sample.get("options"), default=[]))
+    opt_factor = _clip((len(options) - 2) / 8.0) * 100.0 if options else 30.0
+    docs = sample.get("documents", [])
+    hardness, _ = _estimate_retrieval_hardness_and_coverage(str(sample.get("question", "")), docs)
+    return _clip((0.6 * opt_factor + 0.4 * hardness * 100.0) / 100.0) * 100.0
+
+
+def _aok_visual_complexity(sample: dict[str, Any]) -> float:
+    obj = _to_float(_first_non_missing(sample.get("object_count"), sample.get("num_objects"), sample.get("obj_term"), default=0.0), 0.0)
+    texture = _to_float(_first_non_missing(sample.get("texture_contrast"), sample.get("edge_density"), default=0.0), 0.0)
+    text_area = _to_float(_first_non_missing(sample.get("ocr_area_ratio"), sample.get("text_density"), default=0.0), 0.0)
+    has_image, img_cnt = _has_image(sample)
+
+    if obj <= 0 and has_image:
+        obj = 5.0
+    obj_n = _clip(obj / 20.0) if obj > 1.0 else _clip(obj)
+    texture_n = _clip(texture / 0.8) if texture > 1.0 else _clip(texture)
+    text_n = _clip(text_area / 0.8) if text_area > 1.0 else _clip(text_area)
+    img_n = _clip((img_cnt - 1) / 3.0)
+    return _clip(0.45 * obj_n + 0.25 * texture_n + 0.20 * text_n + 0.10 * img_n)
+
+
+def _aok_knowledge_demand(sample: dict[str, Any]) -> float:
+    question = str(sample.get("question", ""))
+    answer = str(sample.get("answer", ""))
+    text = f"{question} {answer}".lower()
+    tokens = _to_token_list(text)
+    token_count = len(tokens)
+
+    technical_hits = sum(1 for k in ["biology", "physics", "chemistry", "law", "finance", "medical", "历史", "地理", "数学"] if k in text)
+    long_token_hits = sum(1 for t in tokens if len(t) >= 9)
+    docs = sample.get("documents", [])
+    doc_factor = _clip((len(docs) if isinstance(docs, list) else 0) / 8.0)
+    rarity_proxy = _clip((technical_hits + long_token_hits / max(token_count, 1) * 4.0) / 6.0)
+    return _clip(0.55 * rarity_proxy + 0.45 * doc_factor)
+
+
+def _aok_reasoning_complexity(sample: dict[str, Any]) -> float:
+    q = str(sample.get("question", "")).lower()
+    base = _clip(_to_float(_first_non_missing(sample.get("reasoning_hops"), sample.get("cot_steps"), sample.get("steps"), default=1.0), 1.0) / 6.0)
+    op_hits = sum(1 for k in ["why", "because", "compare", "difference", "both", "except", "if", "then", "most", "least", "推断", "比较"] if k in q)
+    op_factor = _clip(op_hits / 6.0)
+    options = _to_option_list(_first_non_missing(sample.get("choices"), sample.get("options"), default=[]))
+    option_factor = _clip((len(options) - 2) / 8.0) if options else 0.2
+    return _clip(0.45 * base + 0.35 * op_factor + 0.20 * option_factor)
+
+
+def _aok_emodel_difficulty(sample: dict[str, Any]) -> float:
+    preds = sample.get("model_predictions")
+    gold = str(sample.get("answer", "")).strip().lower()
+    if isinstance(preds, list) and preds:
+        total = 0
+        correct = 0
+        for p in preds:
+            s = str(p).strip().lower()
+            if not s:
+                continue
+            total += 1
+            if s == gold:
+                correct += 1
+        if total > 0:
+            return _clip(1.0 - (correct / total))
+
+    b_exact = sample.get("baseline_exact")
+    if b_exact is not None:
+        try:
+            return 0.0 if bool(b_exact) else 1.0
+        except Exception:
+            pass
+
+    # fallback with retrieval hardness proxy
+    docs = sample.get("documents", [])
+    hardness, _ = _estimate_retrieval_hardness_and_coverage(str(sample.get("question", "")), docs)
+    return _clip(0.5 + 0.5 * hardness)
+
+
+def _mmmu_type_prior(sample: dict[str, Any]) -> float:
+    img_type = str(_first_non_missing(sample.get("img_type"), sample.get("image_type"), sample.get("category"), default="")).lower()
+    if any(k in img_type for k in ["chart", "graph", "plot"]):
+        return 0.8
+    if any(k in img_type for k in ["table", "document", "text"]):
+        return 0.75
+    if any(k in img_type for k in ["diagram", "map", "flow"]):
+        return 0.7
+    if img_type:
+        return 0.65
+    return 0.6
+
+
+def _mmmu_cvision(sample: dict[str, Any]) -> float:
+    obj = _to_float(_first_non_missing(sample.get("obj_term"), sample.get("object_density"), sample.get("num_objects"), default=0.0), 0.0)
+    small = _to_float(_first_non_missing(sample.get("small_term"), sample.get("small_object_ratio"), default=0.0), 0.0)
+    occ = _to_float(_first_non_missing(sample.get("occ_term"), sample.get("occlusion_ratio"), default=0.0), 0.0)
+    text_density = _to_float(sample.get("text_density"), 0.0)
+    n_images = _to_float(_first_non_missing(sample.get("n_images"), sample.get("image_count"), default=1.0), 1.0)
+
+    # normalize signals to 0..1
+    obj_n = _clip(obj / 20.0) if obj > 1.0 else _clip(obj)
+    small_n = _clip(small / 0.5) if small > 1.0 else _clip(small)
+    occ_n = _clip(occ / 0.8) if occ > 1.0 else _clip(occ)
+    text_n = _clip(text_density / 8.0) if text_density > 1.0 else _clip(text_density)
+    multi_n = _clip((n_images - 1.0) / 3.0)
+    type_prior = _mmmu_type_prior(sample)
+
+    return _clip(0.25 * obj_n + 0.15 * small_n + 0.10 * occ_n + 0.20 * text_n + 0.05 * multi_n + 0.25 * type_prior)
+
+
+def _mmmu_cquestion(sample: dict[str, Any]) -> float:
+    question = str(sample.get("question", ""))
+    tokens = _to_token_list(question)
+    q_len = len(tokens)
+    len_tokens = _clip(q_len / 40.0)
+
+    q_lower = question.lower()
+    op_cnt = sum(1 for k in ["compare", "difference", "both", "and", "or", "if", "then", "more", "less", "choose"] if k in q_lower)
+    op_term = _clip(op_cnt / 6.0)
+    num_sym = _clip(sum(ch.isdigit() for ch in question) / max(len(question), 1) / 0.1)
+
+    options = _to_option_list(_first_non_missing(sample.get("choices"), sample.get("options"), default=[]))
+    option_count = len(options)
+    option_term = _clip((option_count - 2) / 8.0) if option_count else 0.4
+
+    if option_count >= 2:
+        lengths = [len(str(o)) for o in options]
+        len_gap = (max(lengths) - min(lengths)) if lengths else 0
+    else:
+        len_gap = 0
+    len_gap_term = _clip(1.0 - (len_gap / max(sum(len(str(o)) for o in options), 1))) if options else 1.0
+
+    # similarity fallback proxy (without external embedding model): overlap of option tokens
+    if option_count >= 2:
+        token_sets = [set(_to_token_list(str(o).lower())) for o in options]
+        sims: list[float] = []
+        for i in range(len(token_sets)):
+            for j in range(i + 1, len(token_sets)):
+                a, b = token_sets[i], token_sets[j]
+                if not a and not b:
+                    sims.append(1.0)
+                else:
+                    sims.append(len(a & b) / max(len(a | b), 1))
+        sim_mean = sum(sims) / max(len(sims), 1)
+        sim_max = max(sims) if sims else 0.0
+    else:
+        sim_mean = 0.0
+        sim_max = 0.0
+
+    return _clip(
+        0.18 * len_tokens
+        + 0.18 * op_term
+        + 0.10 * num_sym
+        + 0.18 * sim_mean
+        + 0.18 * sim_max
+        + 0.12 * option_term
+        + 0.06 * len_gap_term
+    )
+
+
+def _mmmu_depth(sample: dict[str, Any]) -> float:
+    question = str(sample.get("question", ""))
+    q_lower = question.lower()
+    lang_step = 1.0 if any(k in q_lower for k in ["first", "then", "finally", "步骤", "首先", "然后"]) else 0.0
+    n_images = _to_float(_first_non_missing(sample.get("n_images"), sample.get("image_count"), default=1.0), 1.0)
+    multi_img = 1.0 if n_images > 1 else 0.0
+
+    img_type = str(_first_non_missing(sample.get("img_type"), sample.get("image_type"), sample.get("category"), default="")).lower()
+    text_read = 1.0 if any(k in img_type for k in ["chart", "graph", "table", "document", "text"]) else 0.0
+    text_density = _to_float(sample.get("text_density"), 0.0)
+    if text_density > 2.0:
+        text_read = max(text_read, 1.0)
+
+    return _clip((lang_step + 0.6 * multi_img + 0.6 * text_read) / 4.0)
+
+
+def _mmmu_creasoning(sample: dict[str, Any]) -> float:
+    question = str(sample.get("question", "")).lower()
+    if any(k in question for k in ["chart", "graph", "trend", "plot"]):
+        return 0.70
+    if any(k in question for k in ["table", "row", "column", "cell"]):
+        return 0.66
+    if any(k in question for k in ["infer", "why", "reason", "because", "推断", "原因"]):
+        return 0.72
+    if any(k in question for k in ["count", "how many", "数量", "几"]):
+        return 0.62
+    return 0.58
+
+
+def _mmmu_emodel(sample: dict[str, Any]) -> float:
+    # expected signals: prediction accuracy/correct flags; missing => hardest (1.0)
+    acc = _first_non_missing(sample.get("model_accuracy"), sample.get("prediction_accuracy"), default=None)
+    if acc is not None:
+        return _clip(1.0 - _to_float(acc, 0.0))
+
+    preds = sample.get("model_predictions")
+    gold = str(sample.get("answer", "")).strip().lower()
+    if isinstance(preds, list) and preds:
+        correct = 0
+        total = 0
+        for p in preds:
+            ps = str(p).strip().lower()
+            if not ps:
+                continue
+            total += 1
+            if ps == gold:
+                correct += 1
+        if total > 0:
+            return _clip(1.0 - (correct / total))
+
+    baseline_correct = sample.get("baseline_correct")
+    if baseline_correct is not None:
+        try:
+            return 0.0 if bool(baseline_correct) else 1.0
+        except Exception:
+            pass
+    return 1.0
+
+
+def _mmmu_topic_calibration(sample: dict[str, Any]) -> float | None:
+    raw = str(_first_non_missing(sample.get("topic_difficulty"), sample.get("difficulty_level"), default="")).strip().lower()
+    if not raw:
+        return None
+    if raw in {"easy", "low"}:
+        return 0.35
+    if raw in {"medium", "med", "mid"}:
+        return 0.65
+    if raw in {"hard", "high"}:
+        return 0.85
+    return None
+
+
+def _estimate_aokvqa_difficulty(sample: dict[str, Any]) -> DifficultyBreakdown:
+    c_vision = _aok_visual_complexity(sample)
+    c_knowledge = _aok_knowledge_demand(sample)
+    c_reasoning = _aok_reasoning_complexity(sample)
+
+    docs = sample.get("documents", [])
+    retrieval_hardness, coverage = _estimate_retrieval_hardness_and_coverage(str(sample.get("question", "")), docs)
+    options = _to_option_list(_first_non_missing(sample.get("choices"), sample.get("options"), default=[]))
+    ambiguity = _clip((len(options) - 2) / 6) if options else 0.15
+
+    H = _h_score(sample, reasoning_base=c_reasoning)
+    D = _d_score(sample, ambiguity=ambiguity, retrieval_hardness=retrieval_hardness, multimodal=c_vision)
+    O = _o_score(sample, linguistic=_clip(0.65 * c_knowledge + 0.35 * ambiguity))
+    A = _a_score(multimodal=c_vision, coverage=coverage, knowledge=c_knowledge)
+    overall = _combine_hdoa(sample, H, D, O, A)
+
+    return DifficultyBreakdown(
+        overall,
+        linguistic_complexity=O,
+        reasoning_complexity=H,
+        multimodal_complexity=A,
+        knowledge_intensity=c_knowledge,
+        choice_ambiguity=ambiguity,
+        retrieval_hardness=retrieval_hardness,
+        deepresearch_coverage=coverage,
+    )
+
+
+def _estimate_m3cot_difficulty(sample: dict[str, Any]) -> DifficultyBreakdown:
+    vision_score = _m3cot_vision_score(sample) / 100.0
+    question_score = _m3cot_question_score(sample) / 100.0
+    reasoning_score = _m3cot_reasoning_score(sample) / 100.0
+    e_model_score = _m3cot_e_model_score(sample) / 100.0
+
+    docs = sample.get("documents", [])
+    retrieval_hardness, coverage = _estimate_retrieval_hardness_and_coverage(str(sample.get("question", "")), docs)
+    options = _to_option_list(_first_non_missing(sample.get("choices"), sample.get("options"), default=[]))
+    ambiguity = _clip((len(options) - 2) / 6) if options else 0.15
+
+    H = _h_score(sample, reasoning_base=reasoning_score)
+    D = _d_score(sample, ambiguity=ambiguity, retrieval_hardness=retrieval_hardness, multimodal=vision_score)
+    O = _o_score(sample, linguistic=question_score)
+    A = _a_score(multimodal=_clip(0.6 * vision_score + 0.4 * question_score), coverage=coverage, knowledge=e_model_score)
+    overall = _combine_hdoa(sample, H, D, O, A)
+
+    return DifficultyBreakdown(
+        overall,
+        linguistic_complexity=O,
+        reasoning_complexity=H,
+        multimodal_complexity=A,
+        knowledge_intensity=e_model_score,
+        choice_ambiguity=ambiguity,
+        retrieval_hardness=retrieval_hardness,
+        deepresearch_coverage=coverage,
+    )
+
+
+def _estimate_mmmu_difficulty(sample: dict[str, Any]) -> DifficultyBreakdown:
+    cvision = _mmmu_cvision(sample)
+    cquestion = _mmmu_cquestion(sample)
+    depth = _mmmu_depth(sample)
+    creasoning = _mmmu_creasoning(sample)
+    emodel = _mmmu_emodel(sample)
+
+    options = _to_option_list(_first_non_missing(sample.get("choices"), sample.get("options"), default=[]))
+    ambiguity = _clip((len(options) - 2) / 6) if options else 0.15
+    docs = sample.get("documents", [])
+    retrieval_hardness, coverage = _estimate_retrieval_hardness_and_coverage(str(sample.get("question", "")), docs)
+
+    H = _h_score(sample, reasoning_base=depth)
+    D = _d_score(sample, ambiguity=ambiguity, retrieval_hardness=retrieval_hardness, multimodal=cvision)
+    O = _o_score(sample, linguistic=cquestion)
+    A = _a_score(multimodal=_clip(0.6 * cvision + 0.4 * cquestion), coverage=coverage, knowledge=emodel)
+    base = _combine_hdoa(sample, H, D, O, A)
+    calib = _mmmu_topic_calibration(sample)
+    overall = _clip(0.8 * base + 0.2 * calib) if calib is not None else base
+
+    return DifficultyBreakdown(
+        overall=overall,
+        linguistic_complexity=O,
+        reasoning_complexity=H,
+        multimodal_complexity=A,
+        knowledge_intensity=emodel,
+        choice_ambiguity=ambiguity,
+        retrieval_hardness=retrieval_hardness,
+        deepresearch_coverage=coverage,
+    )
+
+
+def estimate_question_difficulty(sample: dict[str, Any]) -> DifficultyBreakdown:
+    """Dataset-aware difficulty estimator for AOKVQA/MMMU-Pro/M3CoT."""
+
+    dataset_type = str(sample.get("dataset_type", "generic")).lower()
+    if dataset_type in {"m3cot"}:
+        return _estimate_m3cot_difficulty(sample)
+    if dataset_type in {"mmmu_pro", "mmmu"}:
+        return _estimate_mmmu_difficulty(sample)
+    if dataset_type in {"generic", "aokvqa", "a_okvqa", "cmmqa", "scienceqa"}:
+        return _estimate_aokvqa_difficulty(sample)
+    return _estimate_aokvqa_difficulty(sample)
+
+
+def _estimate_retrieval_hardness_and_coverage(question: str, docs: Any) -> tuple[float, float]:
+    if not isinstance(docs, list):
+        return 0.85, 0.0
+
+    corpus: list[tuple[str, str]] = []
+    for d in docs:
+        if not isinstance(d, dict):
+            continue
+        source = str(d.get("source", "unknown"))
+        text = str(d.get("text", "")).strip()
+        if text:
+            corpus.append((source, text))
+
+    if not corpus:
+        return 0.9, 0.0
+
+    index = build_graph_from_corpus(corpus)
+    hits = LexicalGraphRetriever(index).retrieve(question, top_k=5)
+    if not hits:
+        return 0.9, 0.0
+
+    scores = [h.score for h in hits]
+    avg_score = mean(scores)
+    hardness = _clip(1.0 / (1.0 + avg_score))
+
+    sources = {h.source for h in hits}
+    total_sources = len({s for s, _ in corpus})
+    coverage = _clip(len(sources) / max(total_sources, 1))
+    return hardness, coverage
+
+
+def difficulty_bucket(v: float, q1: float = 0.34, q2: float = 0.67) -> str:
+    if v <= q1:
+        return "easy"
+    if v <= q2:
+        return "medium"
+    return "hard"

--- a/deepresearch_qwen3_vl/eval_vqa.py
+++ b/deepresearch_qwen3_vl/eval_vqa.py
@@ -1,0 +1,1364 @@
+from __future__ import annotations
+
+import argparse
+import ast
+import base64
+import hashlib
+import json
+import math
+import mimetypes
+import os
+import re
+import tempfile
+from collections import defaultdict
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import mean
+from typing import Any
+
+try:
+    from tqdm import tqdm
+except ModuleNotFoundError:
+    def tqdm(iterable: Any, **_: Any) -> Any:  # type: ignore[misc]
+        return iterable
+
+from difficulty import _task_family, _qnorm_100, difficulty_bucket, estimate_question_difficulty
+from lexical_graph import LexicalGraphRetriever, build_graph_from_corpus
+
+
+@dataclass
+class AblationSetting:
+    use_kg_rag: bool
+    use_difficulty: bool
+    use_sft: bool
+    profile: str
+
+
+def _resolve_ablation(profile: str) -> AblationSetting:
+    table = {
+        "none": AblationSetting(False, False, False, "none"),
+        "kg_only": AblationSetting(True, False, False, "kg_only"),
+        "difficulty_only": AblationSetting(False, True, False, "difficulty_only"),
+        "kg_difficulty": AblationSetting(True, True, False, "kg_difficulty"),
+        "kg_sft": AblationSetting(True, False, True, "kg_sft"),
+        "difficulty_sft": AblationSetting(False, True, True, "difficulty_sft"),
+        "all_on": AblationSetting(True, True, True, "all_on"),
+    }
+    return table.get(profile, table["all_on"])
+
+
+def _jsonable(v: Any) -> Any:
+    if v is None or isinstance(v, (str, int, float, bool)):
+        return v
+    if isinstance(v, (bytes, bytearray)):
+        return {"__type": "bytes", "base64": base64.b64encode(bytes(v)).decode("utf-8")}
+    if isinstance(v, dict):
+        return {str(k): _jsonable(val) for k, val in v.items()}
+    if isinstance(v, (list, tuple, set)):
+        return [_jsonable(x) for x in v]
+    if hasattr(v, "tolist"):
+        try:
+            return _jsonable(v.tolist())
+        except Exception:
+            pass
+    if hasattr(v, "item"):
+        try:
+            return _jsonable(v.item())
+        except Exception:
+            pass
+    return str(v)
+
+
+def _record_key(sample: dict[str, Any]) -> str:
+    original = sample.get("__original_record")
+    if isinstance(original, dict):
+        for k in ["id", "question_id", "image_id"]:
+            v = original.get(k)
+            if v is not None and str(v).strip():
+                return f"id::{k}::{v}"
+    text = f"{sample.get('question','')}||{sample.get('answer','')}"
+    return "sha1::" + hashlib.sha1(text.encode("utf-8", errors="ignore")).hexdigest()
+
+
+def _load_resume_records(path: Path) -> list[dict[str, Any]]:
+    if not path.exists():
+        return []
+    if path.suffix.lower() == ".jsonl":
+        out: list[dict[str, Any]] = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                obj = json.loads(line)
+            except Exception:
+                continue
+            if isinstance(obj, dict):
+                out.append(obj)
+        return out
+    try:
+        raw = json.loads(path.read_text(encoding="utf-8"))
+    except Exception:
+        return []
+    if isinstance(raw, list):
+        return [x for x in raw if isinstance(x, dict)]
+    return []
+
+
+def _tertile_thresholds(values: list[float]) -> tuple[float, float]:
+    if not values:
+        return 0.34, 0.67
+    arr = sorted(values)
+
+    def _q(p: float) -> float:
+        if len(arr) == 1:
+            return arr[0]
+        idx = p * (len(arr) - 1)
+        lo = int(math.floor(idx))
+        hi = int(math.ceil(idx))
+        if lo == hi:
+            return arr[lo]
+        frac = idx - lo
+        return arr[lo] * (1.0 - frac) + arr[hi] * frac
+
+    return _q(1.0 / 3.0), _q(2.0 / 3.0)
+
+
+def normalize(s: str) -> str:
+    return re.sub(r"\s+", "", s.lower())
+
+
+def token_f1(pred: str, gold: str) -> float:
+    p = list(normalize(pred))
+    g = list(normalize(gold))
+    if not p or not g:
+        return 0.0
+    common = 0
+    g_used = [False] * len(g)
+    for ch in p:
+        for i, gg in enumerate(g):
+            if not g_used[i] and ch == gg:
+                g_used[i] = True
+                common += 1
+                break
+    if common == 0:
+        return 0.0
+    precision = common / len(p)
+    recall = common / len(g)
+    return 2 * precision * recall / (precision + recall)
+
+
+def _contains_answer(text: str, answer: str) -> bool:
+    t = normalize(text)
+    a = normalize(answer)
+    return bool(a) and a in t
+
+
+def compute_evidence_metrics(graph_hits: list[Any], docs: list[dict[str, Any]], answer: str) -> tuple[int, float, float]:
+    if not answer:
+        return 0, 0.0, 0.0
+
+    relevant_total = 0
+    for d in docs:
+        txt = str(d.get("text", ""))
+        if txt and _contains_answer(txt, answer):
+            relevant_total += 1
+
+    retrieved_relevant = 0
+    for h in graph_hits:
+        txt = str(getattr(h, "text", ""))
+        if txt and _contains_answer(txt, answer):
+            retrieved_relevant += 1
+
+    retrieved_total = len(graph_hits)
+    hits = int(retrieved_relevant > 0)
+    recall = (retrieved_relevant / relevant_total) if relevant_total > 0 else 0.0
+    precision = (retrieved_relevant / retrieved_total) if retrieved_total > 0 else 0.0
+    return hits, recall, precision
+
+
+def _difficulty_route_tag(overall: float) -> str:
+    if overall > 0.67:
+        return "full_rag"
+    if overall > 0.34:
+        return "light_rag"
+    return "direct_inference"
+
+
+def _sft_role(bucket: str, verification: str) -> str:
+    if bucket == "hard" and verification == "Unverified":
+        return "hard_unverified_primary"
+    if bucket == "hard" and verification == "Verified":
+        return "hard_verified_aux"
+    return "not_selected"
+
+
+def _build_route_aware_graph_context(
+    route: str,
+    question: str,
+    corpus: list[tuple[str, str]],
+) -> tuple[list[Any], str, dict[str, Any]]:
+    if route == "direct_inference":
+        return [], "", {"rounds": 0, "top_k": 0, "expanded_query": None}
+
+    if not corpus:
+        return [], "", {"rounds": 1 if route == "light_rag" else 2, "top_k": 0, "expanded_query": None}
+
+    index = build_graph_from_corpus(corpus)
+    retriever = LexicalGraphRetriever(index)
+
+    if route == "light_rag":
+        graph_hits = retriever.retrieve(question, top_k=4)
+        graph_context = "\n\n".join([f"[{h.source}] {h.text[:600]}" for h in graph_hits])
+        return graph_hits, graph_context, {"rounds": 1, "top_k": 4, "expanded_query": None}
+
+    first_hits = retriever.retrieve(question, top_k=6)
+    expansion_terms: list[str] = []
+    for hit in first_hits[:2]:
+        snippet = str(getattr(hit, "text", ""))[:120]
+        if snippet:
+            expansion_terms.append(snippet)
+    expanded_query = question if not expansion_terms else f"{question}\n补充证据: {' '.join(expansion_terms)}"
+    second_hits = retriever.retrieve(expanded_query, top_k=6)
+
+    merged: list[Any] = []
+    seen = set()
+    for hit in [*first_hits, *second_hits]:
+        key = (getattr(hit, "source", ""), getattr(hit, "text", ""))
+        if key in seen:
+            continue
+        seen.add(key)
+        merged.append(hit)
+
+    graph_context = "\n\n".join([f"[{h.source}] {h.text[:600]}" for h in merged[:8]])
+    return merged[:8], graph_context, {"rounds": 2, "top_k": 6, "expanded_query": expanded_query if expansion_terms else None}
+
+
+def _is_missing(v: Any) -> bool:
+    return v is None or (isinstance(v, float) and math.isnan(v))
+
+
+def _extract_answer(record: dict[str, Any], args: argparse.Namespace) -> str:
+    v = record.get(args.answer_field)
+    if not _is_missing(v):
+        return str(v)
+
+    direct = record.get("direct_answers")
+    if isinstance(direct, list):
+        for x in direct:
+            if not _is_missing(x):
+                return str(x)
+
+    idx = record.get("correct_choice_idx")
+    choices = record.get("choices")
+    if not _is_missing(idx) and choices is not None:
+        try:
+            i = int(idx)
+            if hasattr(choices, "tolist"):
+                choices = choices.tolist()
+            if isinstance(choices, (list, tuple)) and 0 <= i < len(choices):
+                return str(choices[i])
+        except Exception:
+            pass
+
+    raise ValueError("Unable to infer answer; set --answer-field or provide direct_answers / correct_choice_idx+choices.")
+
+
+def _to_choice_list(v: Any) -> list[str]:
+    if v is None:
+        return []
+    if hasattr(v, "tolist"):
+        try:
+            v = v.tolist()
+        except Exception:
+            pass
+    if isinstance(v, (list, tuple)):
+        return [str(x) for x in v]
+    if isinstance(v, str):
+        s = v.strip()
+        if not s:
+            return []
+        try:
+            parsed = ast.literal_eval(s)
+        except (SyntaxError, ValueError):
+            return []
+        if isinstance(parsed, (list, tuple)):
+            return [str(x) for x in parsed]
+    return []
+
+
+def _is_placeholder_image_text(v: str) -> bool:
+    t = v.strip().lower()
+    return t in {"?", "not supported with pagination yet", "none", "null", "nan", ""}
+
+
+def _decode_choice_answer(answer_value: Any, choices: list[str]) -> tuple[str, str | None, int | None]:
+    answer_raw = "" if _is_missing(answer_value) else str(answer_value).strip()
+    if not answer_raw:
+        return "", None, None
+
+    upper = answer_raw.upper().strip()
+    if len(upper) == 1 and "A" <= upper <= "Z":
+        idx = ord(upper) - ord("A")
+        if 0 <= idx < len(choices):
+            return choices[idx], upper, idx
+        return answer_raw, upper, None
+
+    if upper.startswith("(") and upper.endswith(")") and len(upper) == 3:
+        ch = upper[1]
+        if "A" <= ch <= "Z":
+            idx = ord(ch) - ord("A")
+            if 0 <= idx < len(choices):
+                return choices[idx], ch, idx
+
+    return answer_raw, None, None
+
+
+def _extract_mmmu_choices(record: dict[str, Any]) -> list[str]:
+    if "choices" in record:
+        choices = _to_choice_list(record.get("choices"))
+        if choices:
+            return choices
+    if "options" in record:
+        options = _to_choice_list(record.get("options"))
+        if options:
+            return options
+
+    keyed: list[str] = []
+    for k in [
+        "option_a",
+        "option_b",
+        "option_c",
+        "option_d",
+        "option_e",
+        "option_f",
+        "option_g",
+        "option_h",
+        "option_i",
+        "option_j",
+    ]:
+        v = record.get(k)
+        if _is_missing(v):
+            continue
+        keyed.append(str(v))
+    return keyed
+
+
+def _normalize_mmmu_record(record: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    q = record.get(args.question_field)
+    if _is_missing(q):
+        raise ValueError(f"Missing question field: {args.question_field}")
+
+    choices = _extract_mmmu_choices(record)
+    answer_text, answer_label, answer_idx = _decode_choice_answer(record.get(args.answer_field), choices)
+    if not answer_text:
+        answer_text = _extract_answer(record, args)
+
+    sample: dict[str, Any] = {
+        "question": str(q),
+        "answer": answer_text,
+        "choices": choices,
+        "dataset_type": "mmmu_pro",
+    }
+    if answer_label is not None:
+        sample["answer_label"] = answer_label
+    if answer_idx is not None:
+        sample["correct_choice_idx"] = answer_idx
+
+    image_candidates: list[dict[str, Any]] = []
+
+    def _push_image_candidate(value: Any, source_key: str) -> None:
+        if _is_missing(value):
+            return
+        if isinstance(value, dict) and isinstance(value.get("bytes"), (bytes, bytearray)):
+            image_candidates.append({
+                "bytes": bytes(value.get("bytes")),
+                "ext": Path(str(value.get("path", ".jpg"))).suffix or ".jpg",
+                "source": source_key,
+            })
+            return
+        if isinstance(value, str):
+            if _is_placeholder_image_text(value):
+                return
+            vv = value.strip()
+            if vv.startswith("http://") or vv.startswith("https://"):
+                image_candidates.append({"url": vv, "source": source_key})
+            else:
+                image_candidates.append({"path": vv, "source": source_key})
+
+    for key in [
+        args.image_url_field,
+        args.image_path_field,
+        "image",
+        "img_path",
+        "image_1",
+        "image_2",
+        "image_3",
+        "image_4",
+        "image_5",
+        "image_6",
+        "image_7",
+    ]:
+        if not key or key not in record:
+            continue
+        _push_image_candidate(record.get(key), key)
+
+    if image_candidates:
+        sample["__image_candidates"] = image_candidates
+        first = image_candidates[0]
+        if "bytes" in first:
+            sample["__image_bytes"] = first["bytes"]
+            sample["__image_ext"] = first.get("ext", ".jpg")
+        elif "url" in first:
+            sample["image_url"] = first["url"]
+        elif "path" in first:
+            sample["image_path"] = first["path"]
+
+    docs: list[dict[str, str]] = []
+    hint_fields = ["context", "hint", "rationale", "solution", "explanation"]
+    for k in hint_fields:
+        v = record.get(k)
+        if isinstance(v, str) and v.strip() and not _is_placeholder_image_text(v):
+            docs.append({"source": k, "text": v})
+
+    if not docs:
+        docs_value = record.get(args.documents_field) if args.documents_field else None
+        if isinstance(docs_value, list):
+            docs = docs_value
+        elif isinstance(docs_value, str) and docs_value.strip():
+            docs = [{"source": args.documents_field or "context", "text": docs_value}]
+    sample["documents"] = docs
+
+    for k in [
+        "id",
+        "question_id",
+        "image_id",
+        "domain",
+        "category",
+        "subdomain",
+        "topic",
+        "options",
+        "has_table",
+        "has_chart",
+    ]:
+        if k in record:
+            sample[k] = record[k]
+
+    sample["__original_record"] = _jsonable(record)
+    return sample
+
+
+def _normalize_m3cot_record(record: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    q = record.get(args.question_field)
+    if _is_missing(q):
+        raise ValueError(f"Missing question field: {args.question_field}")
+
+    choices = _to_choice_list(record.get("choices"))
+    answer_text, answer_label, answer_idx = _decode_choice_answer(record.get(args.answer_field), choices)
+    if not answer_text:
+        answer_text = _extract_answer(record, args)
+
+    sample: dict[str, Any] = {
+        "question": str(q),
+        "answer": answer_text,
+        "choices": choices,
+        "dataset_type": "m3cot",
+    }
+    if answer_label is not None:
+        sample["answer_label"] = answer_label
+    if answer_idx is not None:
+        sample["correct_choice_idx"] = answer_idx
+
+    for key in [args.image_url_field, args.image_path_field, "image", "img_path"]:
+        if not key or key not in record:
+            continue
+        value = record.get(key)
+        if _is_missing(value) or value == "":
+            continue
+        sample[key] = value
+
+    docs: list[dict[str, str]] = []
+    context = record.get("context")
+    if isinstance(context, str) and context.strip():
+        docs.append({"source": "context", "text": context})
+    rationale = record.get("rationale")
+    if isinstance(rationale, str) and rationale.strip():
+        docs.append({"source": "rationale", "text": rationale})
+    if not docs:
+        docs_value = record.get(args.documents_field) if args.documents_field else None
+        if isinstance(docs_value, list):
+            docs = docs_value
+        elif isinstance(docs_value, str) and docs_value.strip():
+            docs = [{"source": args.documents_field or "context", "text": docs_value}]
+    sample["documents"] = docs
+
+    for k in ["reasoning_hops", "cot_steps", "steps", "domain", "options", "has_table", "has_chart", "topic", "id", "category"]:
+        if k in record:
+            sample[k] = record[k]
+
+    sample["__original_record"] = _jsonable(record)
+    return sample
+
+
+def _normalize_cmmqa_record(record: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    q = record.get(args.question_field)
+    if _is_missing(q):
+        raise ValueError(f"Missing question field: {args.question_field}")
+
+    choices_raw = record.get("choices")
+    if _is_missing(choices_raw):
+        choices_raw = record.get("options")
+    choices = _to_choice_list(choices_raw)
+    answer_text, answer_label, answer_idx = _decode_choice_answer(record.get(args.answer_field), choices)
+    if not answer_text:
+        answer_text = _extract_answer(record, args)
+
+    sample: dict[str, Any] = {
+        "question": str(q),
+        "answer": answer_text,
+        "choices": choices,
+        "dataset_type": "cmmqa",
+    }
+    if answer_label is not None:
+        sample["answer_label"] = answer_label
+    if answer_idx is not None:
+        sample["correct_choice_idx"] = answer_idx
+
+    for key in [args.image_url_field, args.image_path_field, "image", "img_path", "image_url"]:
+        if not key or key not in record:
+            continue
+        value = record.get(key)
+        if _is_missing(value) or value == "":
+            continue
+        sample[key] = value
+
+    docs: list[dict[str, str]] = []
+    reasoning_chains = record.get("reasoning_chains")
+    if isinstance(reasoning_chains, list) and reasoning_chains:
+        chain_lines: list[str] = []
+        for idx, chain in enumerate(reasoning_chains, start=1):
+            if isinstance(chain, (list, tuple)) and len(chain) >= 3:
+                chain_lines.append(f"{idx}. {chain[0]} --{chain[1]}--> {chain[2]}")
+            elif isinstance(chain, str) and chain.strip():
+                chain_lines.append(f"{idx}. {chain.strip()}")
+        if chain_lines:
+            docs.append({"source": "reasoning_chains", "text": "\n".join(chain_lines)})
+    sample["documents"] = docs
+
+    for k in ["ID", "id", "question_id", "image_id", "image", "image_url", "reasoning_chains"]:
+        if k in record:
+            sample[k] = record[k]
+
+    sample["__original_record"] = _jsonable(record)
+    return sample
+
+
+def _normalize_scienceqa_record(record: dict[str, Any], args: argparse.Namespace) -> dict[str, Any]:
+    q = record.get(args.question_field)
+    if _is_missing(q):
+        raise ValueError(f"Missing question field: {args.question_field}")
+
+    choices_raw = record.get("choices")
+    if _is_missing(choices_raw):
+        choices_raw = record.get("options")
+    choices = _to_choice_list(choices_raw)
+    answer_value = record.get(args.answer_field)
+    answer_text = ""
+    answer_label: str | None = None
+    answer_idx: int | None = None
+
+    if isinstance(answer_value, int) and 0 <= answer_value < len(choices):
+        answer_idx = int(answer_value)
+        answer_label = chr(ord("A") + answer_idx)
+        answer_text = choices[answer_idx]
+    else:
+        answer_text, answer_label, answer_idx = _decode_choice_answer(answer_value, choices)
+    if not answer_text:
+        answer_text = _extract_answer(record, args)
+
+    sample: dict[str, Any] = {
+        "question": str(q),
+        "answer": answer_text,
+        "choices": choices,
+        "dataset_type": "scienceqa",
+    }
+    if answer_label is not None:
+        sample["answer_label"] = answer_label
+    if answer_idx is not None:
+        sample["correct_choice_idx"] = answer_idx
+
+    rid = None
+    for key in ["id", "ID", "question_id", "__record_id"]:
+        v = record.get(key)
+        if _is_missing(v):
+            continue
+        rid = v
+        break
+    split_value = record.get("split")
+    split = "train" if _is_missing(split_value) else str(split_value)
+    image_name = record.get("image")
+    if isinstance(image_name, str) and image_name.strip():
+        if split and rid is not None:
+            sample["image_path"] = f"{split}/{rid}/{image_name.strip()}"
+        else:
+            sample["image_path"] = image_name.strip()
+
+    docs: list[dict[str, str]] = []
+    for k in ["hint", "lecture", "solution"]:
+        v = record.get(k)
+        if isinstance(v, str) and v.strip():
+            docs.append({"source": k, "text": v})
+    sample["documents"] = docs
+
+    for k in [
+        "id",
+        "ID",
+        "split",
+        "task",
+        "grade",
+        "subject",
+        "topic",
+        "category",
+        "skill",
+        "image",
+    ]:
+        if k in record:
+            sample[k] = record[k]
+
+    sample["__original_record"] = _jsonable(record)
+    return sample
+
+
+def _infer_dataset_type(args: argparse.Namespace, record: dict[str, Any], dataset_path: Path) -> str:
+    if args.dataset_type != "auto":
+        return args.dataset_type
+    path_l = str(dataset_path).lower()
+    if "scienceqa" in path_l:
+        return "scienceqa"
+    if "cmmqa" in path_l:
+        return "cmmqa"
+    if "mmmu" in path_l:
+        return "mmmu_pro"
+    if "m3cot" in path_l:
+        return "m3cot"
+    if {"question_id", "image_id"}.intersection(record.keys()) and (
+        "options" in record or "choices" in record or "option_a" in record
+    ):
+        return "mmmu_pro"
+    if {"rationale", "topic", "category", "image_id"}.intersection(record.keys()) and "choices" in record:
+        return "m3cot"
+    return "generic"
+
+
+def _normalize_sample_record(record: dict[str, Any], args: argparse.Namespace, dataset_type: str = "generic") -> dict[str, Any]:
+    if dataset_type == "mmmu_pro":
+        return _normalize_mmmu_record(record, args)
+    if dataset_type == "m3cot":
+        return _normalize_m3cot_record(record, args)
+    if dataset_type == "cmmqa":
+        return _normalize_cmmqa_record(record, args)
+    if dataset_type == "scienceqa":
+        return _normalize_scienceqa_record(record, args)
+
+    q = record.get(args.question_field)
+    if _is_missing(q):
+        raise ValueError(f"Missing question field: {args.question_field}")
+
+    sample: dict[str, Any] = {"question": str(q), "answer": _extract_answer(record, args)}
+
+    for key in [args.image_url_field, args.image_path_field, "image", "img_path"]:
+        if not key or key not in record:
+            continue
+        value = record.get(key)
+        if _is_missing(value) or value == "":
+            continue
+
+        if key == "image" and isinstance(value, dict) and isinstance(value.get("bytes"), (bytes, bytearray)):
+            sample["__image_bytes"] = bytes(value.get("bytes"))
+            sample["__image_ext"] = ".jpg"
+            continue
+
+        sample[key] = value
+
+    docs_value = record.get(args.documents_field) if args.documents_field else None
+    if isinstance(docs_value, list):
+        sample["documents"] = docs_value
+    elif isinstance(docs_value, str) and docs_value.strip():
+        sample["documents"] = [{"source": args.documents_field or "context", "text": docs_value}]
+    else:
+        sample["documents"] = []
+
+    for k in ["reasoning_hops", "cot_steps", "steps", "domain", "choices", "options", "has_table", "has_chart"]:
+        if k in record:
+            sample[k] = record[k]
+
+    sample["dataset_type"] = "generic"
+    sample["__original_record"] = _jsonable(record)
+    return sample
+
+
+def load_dataset(dataset_path: Path, args: argparse.Namespace) -> list[dict[str, Any]]:
+    if dataset_path.is_dir():
+        parquet_files = sorted(dataset_path.glob("*.parquet"))
+        if not parquet_files:
+            raise ValueError(f"No parquet files found in dataset directory: {dataset_path}")
+        merged_records: list[dict[str, Any]] = []
+        for pf in parquet_files:
+            merged_records.extend(load_dataset(pf, args))
+        return merged_records
+
+    suffix = dataset_path.suffix.lower()
+
+    def _normalize_records(records: list[dict[str, Any]]) -> list[dict[str, Any]]:
+        vision_map = _load_mmmu_vision_map(args)
+        out: list[dict[str, Any]] = []
+        for x in records:
+            if not isinstance(x, dict):
+                continue
+            ds_type = _infer_dataset_type(args, x, dataset_path)
+            record = dict(x)
+            if ds_type == "mmmu_pro":
+                merged = _merge_mmmu_vision_record(record, vision_map, args)
+                out.append(_normalize_sample_record(merged, args, dataset_type=ds_type))
+            else:
+                out.append(_normalize_sample_record(record, args, dataset_type=ds_type))
+        return out
+
+    if suffix == ".json":
+        raw = json.loads(dataset_path.read_text())
+        if isinstance(raw, list):
+            return _normalize_records(raw)
+        if isinstance(raw, dict):
+            unpacked: list[dict[str, Any]] = []
+            for k, v in raw.items():
+                if isinstance(v, dict):
+                    item = dict(v)
+                    item.setdefault("__record_id", str(k))
+                    item.setdefault("id", str(k))
+                    unpacked.append(item)
+            if unpacked:
+                return _normalize_records(unpacked)
+        raise ValueError("JSON dataset must be a list of objects or a dict[id->object].")
+
+    if suffix == ".jsonl":
+        out = []
+        for line in dataset_path.read_text().splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            obj = json.loads(line)
+            if isinstance(obj, dict):
+                out.append(obj)
+        return _normalize_records(out)
+
+    if suffix == ".parquet":
+        try:
+            import pandas as pd
+        except ModuleNotFoundError as exc:
+            raise ModuleNotFoundError(
+                "Reading parquet datasets requires pandas (and pyarrow/fastparquet). Please install requirements.txt first."
+            ) from exc
+        df = pd.read_parquet(dataset_path)
+        records = df.to_dict(orient="records")
+        return _normalize_records(records)
+
+    raise ValueError(f"Unsupported dataset format: {suffix}. Use .json/.jsonl/.parquet")
+
+
+def _vision_record_id(record: dict[str, Any], key_hint: str) -> str | None:
+    candidates = [key_hint, "id", "question_id", "image_id", "sample_id"]
+    for k in candidates:
+        if not k:
+            continue
+        v = record.get(k)
+        if _is_missing(v):
+            continue
+        s = str(v).strip()
+        if s:
+            return s
+    return None
+
+
+def _load_mmmu_vision_map(args: argparse.Namespace) -> dict[str, dict[str, Any]]:
+    vision_path = args.mmmu_vision_parquet
+    if vision_path is None:
+        return {}
+    if not vision_path.exists():
+        return {}
+    try:
+        import pandas as pd
+    except ModuleNotFoundError:
+        return {}
+
+    vision_files: list[Path]
+    if vision_path.is_dir():
+        vision_files = sorted(vision_path.glob("*.parquet"))
+    else:
+        vision_files = [vision_path]
+    if not vision_files:
+        return {}
+
+    out: dict[str, dict[str, Any]] = {}
+    for vf in vision_files:
+        records = pd.read_parquet(vf).to_dict(orient="records")
+        for rec in records:
+            if not isinstance(rec, dict):
+                continue
+            rid = _vision_record_id(rec, args.mmmu_vision_id_field)
+            if rid:
+                out[rid] = rec
+    return out
+
+
+def _merge_mmmu_vision_record(record: dict[str, Any], vision_map: dict[str, dict[str, Any]], args: argparse.Namespace) -> dict[str, Any]:
+    if not vision_map:
+        return record
+    rid = _vision_record_id(record, args.mmmu_id_field)
+    if not rid:
+        return record
+    vision = vision_map.get(rid)
+    if not vision:
+        return record
+
+    merged = dict(record)
+    image_field = args.mmmu_vision_image_field
+    if image_field in vision and "image" not in merged and "image_path" not in merged and "img_path" not in merged:
+        merged["image"] = vision.get(image_field)
+    for k in ["image_1", "image_2", "image_3", "image_4", "image_5", "image_6", "image_7"]:
+        if k in vision and k not in merged:
+            merged[k] = vision.get(k)
+    if "image_path" in vision and "image_path" not in merged:
+        merged["image_path"] = vision.get("image_path")
+    if "image_url" in vision and "image_url" not in merged:
+        merged["image_url"] = vision.get("image_url")
+    return merged
+
+
+def _image_path_to_data_url(path: Path) -> str:
+    mime, _ = mimetypes.guess_type(str(path))
+    if not mime:
+        mime = "image/jpeg"
+    b64 = base64.b64encode(path.read_bytes()).decode("utf-8")
+    return f"data:{mime};base64,{b64}"
+
+
+def _image_bytes_to_data_url(img_bytes: bytes, ext: str = ".jpg") -> str:
+    mime_map = {".jpg": "image/jpeg", ".jpeg": "image/jpeg", ".png": "image/png", ".webp": "image/webp"}
+    mime = mime_map.get(ext.lower(), "image/jpeg")
+    b64 = base64.b64encode(img_bytes).decode("utf-8")
+    return f"data:{mime};base64,{b64}"
+
+
+def resolve_image_reference(sample: dict[str, Any], image_root: Path | None = None) -> tuple[str | None, str | None]:
+    candidates = sample.get("__image_candidates")
+    if isinstance(candidates, list):
+        for c in candidates:
+            if not isinstance(c, dict):
+                continue
+            if isinstance(c.get("url"), str) and c.get("url", "").strip():
+                return c["url"].strip(), str(c.get("source", "image_url"))
+            if isinstance(c.get("bytes"), (bytes, bytearray)):
+                return _image_bytes_to_data_url(bytes(c["bytes"]), str(c.get("ext", ".jpg"))), str(c.get("source", "image_bytes"))
+            if isinstance(c.get("path"), str) and c.get("path", "").strip():
+                sample = dict(sample)
+                sample["image_path"] = c["path"]
+                break
+
+    image_url = sample.get("image_url")
+    if isinstance(image_url, str) and image_url.strip():
+        return image_url.strip(), "image_url"
+
+    img_bytes = sample.get("__image_bytes")
+    if isinstance(img_bytes, (bytes, bytearray)):
+        return _image_bytes_to_data_url(bytes(img_bytes), sample.get("__image_ext", ".jpg")), "image_bytes"
+
+    candidate = sample.get("image_path") or sample.get("image") or sample.get("img_path")
+    if isinstance(candidate, str) and candidate.strip():
+        raw = candidate.strip()
+        if _is_placeholder_image_text(raw):
+            return None, None
+        norm = raw.replace("\\", "/")
+        path_candidates: list[Path] = []
+
+        base = Path(norm)
+        path_candidates.append(base)
+        if image_root is not None:
+            path_candidates.append(image_root / base)
+            parts = base.parts
+            if len(parts) >= 2 and parts[0].lower() == "data" and parts[1].lower() == "images":
+                path_candidates.append(image_root / Path(*parts[2:]))
+            path_candidates.append(image_root / base.name)
+
+        seen: set[Path] = set()
+        for p in path_candidates:
+            try:
+                rp = p.expanduser().resolve()
+            except Exception:
+                continue
+            if rp in seen:
+                continue
+            seen.add(rp)
+            if rp.exists():
+                return _image_path_to_data_url(rp), "image_path"
+
+    return None, None
+
+
+def answer_with_context(
+    llm: Any,
+    question: str,
+    context: str,
+    image_ref: str | None = None,
+    dataset_type: str = "generic",
+    choices: list[str] | None = None,
+) -> str:
+    if llm is None:
+        return context[:80] or "insufficient_context"
+
+    if dataset_type in {"mmmu_pro", "cmmqa", "scienceqa"} and choices:
+        opts = []
+        max_opts = min(len(choices), 10)
+        for i in range(max_opts):
+            label = chr(ord("A") + i)
+            opts.append(f"{label}. {choices[i]}")
+        option_text = "\n".join(opts)
+        if dataset_type == "cmmqa":
+            prompt = (
+                "你是CMMQA多模态知识问答评测助手。请先识别图像中的关键实体，再结合给定知识链上下文做两跳以上约束推理。"
+                "仅输出一个选项字母（A-J），不要输出解释。\n"
+                f"题目: {question}\n"
+                f"选项:\n{option_text}\n"
+                f"知识链上下文:\n{context[:1400]}"
+            )
+        elif dataset_type == "scienceqa":
+            prompt = (
+                "你是ScienceQA多模态评测助手。请先定位题目中的科学概念与图像线索，再结合提示(hint)/讲义(lecture)进行约束推理。"
+                "仅输出一个选项字母（A-J），不要输出解释。\n"
+                f"题目: {question}\n"
+                f"选项:\n{option_text}\n"
+                f"辅助上下文:\n{context[:1600]}"
+            )
+        else:
+            prompt = (
+                "你是MMMU-Pro多模态选择题评测助手。"
+                "仅输出一个选项字母（A-J），不要输出解释。\n"
+                f"题目: {question}\n"
+                f"选项:\n{option_text}\n"
+                f"辅助上下文:\n{context[:1200]}"
+            )
+    else:
+        prompt = (
+            "你是知识增强型多模态VQA助手。基于给定上下文回答问题，"
+            "若上下文不足则明确说明。只输出简洁答案。\n"
+            f"问题: {question}\n上下文:\n{context[:4000]}"
+        )
+    if image_ref:
+        return llm.chat_with_image(prompt=prompt, image_url=image_ref, temperature=0.1)
+    return llm.chat(
+        [{"role": "system", "content": "你是VQA评测助手"}, {"role": "user", "content": prompt}],
+        temperature=0.1,
+    )
+
+
+def refine_with_sft(
+    llm: Any,
+    question: str,
+    first_answer: str,
+    context: str,
+    image_ref: str | None = None,
+    dataset_type: str = "generic",
+    choices: list[str] | None = None,
+) -> str:
+    if llm is None:
+        return first_answer
+    opts = []
+    if choices:
+        for i, ch in enumerate(choices[:10]):
+            opts.append(f"{chr(ord('A') + i)}. {ch}")
+    prompt = (
+        "你是一次轻量SFT后精炼助手。请结合首轮答案和证据进行一次自校正，仅输出最终答案。"
+        "如果是选择题，仅输出选项字母。\n"
+        f"题目: {question}\n"
+        f"首轮答案: {first_answer}\n"
+        f"选项:\n{chr(10).join(opts)}\n"
+        f"证据上下文:\n{context[:2000]}\n"
+        f"数据集类型: {dataset_type}"
+    )
+    if image_ref:
+        return llm.chat_with_image(prompt=prompt, image_url=image_ref, temperature=0.1)
+    return llm.chat(
+        [{"role": "system", "content": "你是VQA评测助手"}, {"role": "user", "content": prompt}],
+        temperature=0.1,
+    )
+
+
+def run_eval(dataset_path: Path, args: argparse.Namespace) -> dict:
+    data = load_dataset(dataset_path, args)
+    ablation = _resolve_ablation(str(getattr(args, "ablation_profile", "all_on")))
+    llm = None
+    if not args.mock:
+        from models import QwenVLClient
+
+        llm = QwenVLClient()
+
+    records: list[dict[str, Any]] = []
+    seen_keys: set[str] = set()
+
+    resume_path = args.resume_from
+    if resume_path is not None:
+        resumed = _load_resume_records(resume_path)
+        for r in resumed:
+            if not isinstance(r, dict):
+                continue
+            k = r.get("sample_key")
+            if not isinstance(k, str) or not k:
+                continue
+            seen_keys.add(k)
+            records.append(r)
+
+    progress = tqdm(data, desc="Evaluating", unit="sample", dynamic_ncols=True)
+    for sample in progress:
+        sample_key = _record_key(sample)
+        if sample_key in seen_keys:
+            continue
+
+        q = sample["question"]
+        gold = sample["answer"]
+        if ablation.use_difficulty:
+            diff = estimate_question_difficulty(sample)
+            route = _difficulty_route_tag(diff.overall) if ablation.use_kg_rag else "direct_inference"
+        else:
+            diff = estimate_question_difficulty(
+                {
+                    "dataset_type": str(sample.get("dataset_type", "generic")),
+                    "question": str(sample.get("question", "")),
+                    "choices": sample.get("choices", []),
+                }
+            )
+            route = "full_rag" if ablation.use_kg_rag else "direct_inference"
+        image_ref, image_source = resolve_image_reference(sample, image_root=args.image_root)
+        docs = sample.get("documents", [])
+
+        corpus = [(str(d.get("source", "unknown")), str(d.get("text", ""))) for d in docs if d.get("text")]
+        baseline_context = "\n\n".join([f"[{s}] {t[:600]}" for s, t in corpus[:4]])
+        if ablation.use_kg_rag:
+            graph_hits, graph_context, route_meta = _build_route_aware_graph_context(route=route, question=q, corpus=corpus)
+            hits, evidence_recall, evidence_precision = compute_evidence_metrics(graph_hits, docs, gold)
+        else:
+            graph_hits, graph_context, route_meta = [], "", {"rounds": 0, "top_k": 0, "expanded_query": None}
+            hits, evidence_recall, evidence_precision = 0, 0.0, 0.0
+
+        baseline_error = None
+        graph_error = None
+        try:
+            baseline_pred = answer_with_context(
+                llm,
+                q,
+                baseline_context,
+                image_ref=image_ref,
+                dataset_type=str(sample.get("dataset_type", "generic")),
+                choices=_to_choice_list(sample.get("choices")),
+            )
+        except Exception as exc:  # keep eval running
+            baseline_pred = ""
+            baseline_error = str(exc)
+
+        try:
+            graph_pred = answer_with_context(
+                llm,
+                q,
+                graph_context if graph_context else baseline_context,
+                image_ref=image_ref,
+                dataset_type=str(sample.get("dataset_type", "generic")),
+                choices=_to_choice_list(sample.get("choices")),
+            )
+            if ablation.use_sft:
+                graph_pred = refine_with_sft(
+                    llm=llm,
+                    question=q,
+                    first_answer=graph_pred,
+                    context=(graph_context if graph_context else baseline_context),
+                    image_ref=image_ref,
+                    dataset_type=str(sample.get("dataset_type", "generic")),
+                    choices=_to_choice_list(sample.get("choices")),
+                )
+        except Exception as exc:
+            graph_pred = ""
+            graph_error = str(exc)
+
+        rec = {
+            "sample_key": sample_key,
+            "question": q,
+            "gold": gold,
+            "baseline_pred": baseline_pred,
+            "graph_pred": graph_pred,
+            "baseline_exact": int(normalize(baseline_pred) == normalize(gold)),
+            "graph_exact": int(normalize(graph_pred) == normalize(gold)),
+            "baseline_f1": token_f1(baseline_pred, gold),
+            "graph_f1": token_f1(graph_pred, gold),
+            "hits": hits,
+            "evidence_recall": evidence_recall,
+            "evidence_precision": evidence_precision,
+            "image_used": bool(image_ref),
+            "image_source": image_source,
+            "baseline_error": baseline_error,
+            "graph_error": graph_error,
+            "difficulty": {
+                "overall": diff.overall,
+                "qnorm_100": _qnorm_100(diff.overall),
+                "bucket": "pending",
+                "route": route,
+                "task_family": _task_family(sample),
+                "linguistic_complexity": diff.linguistic_complexity,
+                "reasoning_complexity": diff.reasoning_complexity,
+                "multimodal_complexity": diff.multimodal_complexity,
+                "knowledge_intensity": diff.knowledge_intensity,
+                "choice_ambiguity": diff.choice_ambiguity,
+                "retrieval_hardness": diff.retrieval_hardness,
+                "deepresearch_coverage": diff.deepresearch_coverage,
+            },
+            "retrieval_trace": route_meta,
+            "ablation": {
+                "profile": ablation.profile,
+                "kg_rag": ablation.use_kg_rag,
+                "difficulty_estimator": ablation.use_difficulty,
+                "sft_refine": ablation.use_sft,
+            },
+            "verification": "Verified" if int(normalize(graph_pred) == normalize(gold)) == 1 else "Unverified",
+            "original_record": sample.get("__original_record", {}),
+            "normalized_sample": {
+                k: _jsonable(v)
+                for k, v in sample.items()
+                if not k.startswith("__")
+            },
+        }
+        records.append(rec)
+        seen_keys.add(sample_key)
+
+        if args.details_out is not None and args.save_every > 0 and len(records) % args.save_every == 0:
+            args.details_out.parent.mkdir(parents=True, exist_ok=True)
+            if args.details_format == "jsonl":
+                with args.details_out.open("w", encoding="utf-8") as f:
+                    for item in records:
+                        f.write(json.dumps(item, ensure_ascii=False) + "\n")
+            else:
+                args.details_out.write_text(json.dumps(records, ensure_ascii=False, indent=2), encoding="utf-8")
+
+        if hasattr(progress, "set_postfix"):
+            progress.set_postfix(
+                baseline_err=sum(1 for r in records if r["baseline_error"]),
+                graph_err=sum(1 for r in records if r["graph_error"]),
+                img=sum(1 for r in records if r["image_used"]),
+            )
+
+    difficulty_values = [float(r.get("difficulty", {}).get("overall", 0.0)) for r in records]
+    q1, q2 = _tertile_thresholds(difficulty_values)
+    by_bucket: dict[str, list[dict[str, Any]]] = defaultdict(list)
+    for r in records:
+        overall = float(r.get("difficulty", {}).get("overall", 0.0))
+        b = difficulty_bucket(overall, q1=q1, q2=q2)
+        r.setdefault("difficulty", {})["bucket"] = b
+        r["sft_role"] = _sft_role(b, str(r.get("verification", "Unverified")))
+        by_bucket[b].append(r)
+
+    n = max(len(records), 1)
+    score_components = {
+        "overall": mean([r["difficulty"]["overall"] for r in records]) if records else 0.0,
+        "linguistic_complexity": mean([r["difficulty"]["linguistic_complexity"] for r in records]) if records else 0.0,
+        "reasoning_complexity": mean([r["difficulty"]["reasoning_complexity"] for r in records]) if records else 0.0,
+        "multimodal_complexity": mean([r["difficulty"]["multimodal_complexity"] for r in records]) if records else 0.0,
+        "knowledge_intensity": mean([r["difficulty"]["knowledge_intensity"] for r in records]) if records else 0.0,
+        "choice_ambiguity": mean([r["difficulty"]["choice_ambiguity"] for r in records]) if records else 0.0,
+        "retrieval_hardness": mean([r["difficulty"]["retrieval_hardness"] for r in records]) if records else 0.0,
+        "deepresearch_coverage": mean([r["difficulty"]["deepresearch_coverage"] for r in records]) if records else 0.0,
+        "image_input_coverage": (sum(1 for r in records if r["image_used"]) / n) if records else 0.0,
+        "baseline_error_rate": (sum(1 for r in records if r["baseline_error"]) / n) if records else 0.0,
+        "graph_error_rate": (sum(1 for r in records if r["graph_error"]) / n) if records else 0.0,
+        "verified_rate": (sum(1 for r in records if r.get("verification") == "Verified") / n) if records else 0.0,
+    }
+
+    bucket_metrics = {}
+    for bucket, items in by_bucket.items():
+        m = max(len(items), 1)
+        bucket_metrics[bucket] = {
+            "count": len(items),
+            "baseline_exact": sum(x["baseline_exact"] for x in items) / m,
+            "graph_exact": sum(x["graph_exact"] for x in items) / m,
+            "baseline_f1": sum(x["baseline_f1"] for x in items) / m,
+            "graph_f1": sum(x["graph_f1"] for x in items) / m,
+            "avg_difficulty": mean([x["difficulty"]["overall"] for x in items]) if items else 0.0,
+            "image_input_coverage": sum(1 for x in items if x["image_used"]) / m,
+        }
+
+    return {
+        "count": len(records),
+        "baseline_exact": sum(r["baseline_exact"] for r in records) / n,
+        "graph_exact": sum(r["graph_exact"] for r in records) / n,
+        "baseline_f1": sum(r["baseline_f1"] for r in records) / n,
+        "graph_f1": sum(r["graph_f1"] for r in records) / n,
+        "hits": sum(r.get("hits", 0) for r in records) / n,
+        "evidence_recall": sum(float(r.get("evidence_recall", 0.0)) for r in records) / n,
+        "evidence_precision": sum(float(r.get("evidence_precision", 0.0)) for r in records) / n,
+        "difficulty_scores": score_components,
+        "difficulty_bucket_thresholds": {"q33": q1, "q67": q2},
+        "route_stats": {
+            "direct_inference": sum(1 for r in records if r.get("difficulty", {}).get("route") == "direct_inference"),
+            "light_rag": sum(1 for r in records if r.get("difficulty", {}).get("route") == "light_rag"),
+            "full_rag": sum(1 for r in records if r.get("difficulty", {}).get("route") == "full_rag"),
+        },
+        "verification_stats": {
+            "verified": sum(1 for r in records if r.get("verification") == "Verified"),
+            "unverified": sum(1 for r in records if r.get("verification") == "Unverified"),
+            "hard_verified": sum(
+                1
+                for r in records
+                if r.get("verification") == "Verified" and r.get("difficulty", {}).get("bucket") == "hard"
+            ),
+            "hard_unverified": sum(
+                1
+                for r in records
+                if r.get("verification") == "Unverified" and r.get("difficulty", {}).get("bucket") == "hard"
+            ),
+        },
+        "sft_sampling_stats": {
+            "hard_unverified_primary": sum(1 for r in records if r.get("sft_role") == "hard_unverified_primary"),
+            "hard_verified_aux": sum(1 for r in records if r.get("sft_role") == "hard_verified_aux"),
+        },
+        "accuracy_stats": {
+            "baseline_correct": int(sum(r["baseline_exact"] for r in records)),
+            "graph_correct": int(sum(r["graph_exact"] for r in records)),
+            "total": int(len(records)),
+            "baseline_accuracy": (sum(r["baseline_exact"] for r in records) / n),
+            "graph_accuracy": (sum(r["graph_exact"] for r in records) / n),
+        },
+        "metrics_by_difficulty_bucket": bucket_metrics,
+        "details": records,
+    }
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Evaluate lexical-graph enhanced multimodal VQA in DeepResearch")
+    parser.add_argument("dataset", type=Path, help="Path to dataset file (.json/.jsonl/.parquet)")
+    parser.add_argument("--out", type=Path, default=Path("vqa_eval_report.json"))
+    parser.add_argument("--mock", action="store_true", help="Run without LLM API calls")
+    parser.add_argument("--model-name", type=str, default=None, help="Override MODEL_NAME for this eval run")
+    parser.add_argument("--openai-base-url", type=str, default=None, help="Override OPENAI_BASE_URL for this eval run")
+    parser.add_argument("--openai-api-key", type=str, default=None, help="Override OPENAI_API_KEY for this eval run")
+    parser.add_argument("--image-root", type=Path, default=None, help="Root folder for relative image paths")
+    parser.add_argument("--question-field", type=str, default="question", help="Question column/key name")
+    parser.add_argument("--answer-field", type=str, default="answer", help="Answer column/key name")
+    parser.add_argument("--documents-field", type=str, default="documents", help="Documents/context column/key name")
+    parser.add_argument("--image-url-field", type=str, default="image_url", help="Image URL column/key name")
+    parser.add_argument("--image-path-field", type=str, default="image_path", help="Image path column/key name")
+    parser.add_argument(
+        "--dataset-type",
+        choices=["auto", "generic", "m3cot", "mmmu_pro", "cmmqa", "scienceqa"],
+        default="auto",
+        help="Dataset parser type. auto keeps A-OKVQA logic and applies M3COT/MMMU-Pro/CMMQA/ScienceQA normalization when detected.",
+    )
+    parser.add_argument(
+        "--ablation-profile",
+        choices=["none", "kg_only", "difficulty_only", "kg_difficulty", "kg_sft", "difficulty_sft", "all_on"],
+        default="all_on",
+        help="Ablation assembly profile matching module switches: KG-RAG / difficulty estimator / SFT-refine.",
+    )
+    parser.add_argument(
+        "--mmmu-vision-parquet",
+        type=Path,
+        default=None,
+        help="Optional MMMU-Pro vision parquet file OR directory (joined for separated question/vision parquet setup).",
+    )
+    parser.add_argument(
+        "--mmmu-id-field",
+        type=str,
+        default="id",
+        help="ID field in MMMU-Pro question parquet used to join with --mmmu-vision-parquet.",
+    )
+    parser.add_argument(
+        "--mmmu-vision-id-field",
+        type=str,
+        default="id",
+        help="ID field in MMMU-Pro vision parquet used for join mapping.",
+    )
+    parser.add_argument(
+        "--mmmu-vision-image-field",
+        type=str,
+        default="image",
+        help="Image payload field in MMMU-Pro vision parquet (default: image).",
+    )
+    parser.add_argument(
+        "--details-out",
+        type=Path,
+        default=None,
+        help="Optional path to save per-sample complete records with original fields + eval result (.json or .jsonl)",
+    )
+    parser.add_argument(
+        "--details-format",
+        choices=["json", "jsonl"],
+        default="json",
+        help="Format for --details-out (default: json)",
+    )
+    parser.add_argument(
+        "--resume-from",
+        type=Path,
+        default=None,
+        help="Resume evaluation from an existing details file (.json/.jsonl). Already completed samples will be skipped.",
+    )
+    parser.add_argument(
+        "--save-every",
+        type=int,
+        default=0,
+        help="If >0 and --details-out is set, periodically checkpoint details every N processed samples.",
+    )
+    args = parser.parse_args()
+
+    if args.model_name:
+        os.environ["MODEL_NAME"] = args.model_name
+    if args.openai_base_url:
+        os.environ["OPENAI_BASE_URL"] = args.openai_base_url
+    if args.openai_api_key:
+        os.environ["OPENAI_API_KEY"] = args.openai_api_key
+
+    report = run_eval(args.dataset, args=args)
+    args.out.write_text(json.dumps(report, ensure_ascii=False, indent=2))
+
+    if args.details_out is not None:
+        details = report.get("details", [])
+        args.details_out.parent.mkdir(parents=True, exist_ok=True)
+        if args.details_format == "jsonl":
+            with args.details_out.open("w", encoding="utf-8") as f:
+                for item in details:
+                    f.write(json.dumps(item, ensure_ascii=False) + "\n")
+        else:
+            args.details_out.write_text(json.dumps(details, ensure_ascii=False, indent=2), encoding="utf-8")
+
+    print("=== Global Metrics ===")
+    print(json.dumps({
+        "count": report["count"],
+        "baseline_exact": report["baseline_exact"],
+        "graph_exact": report["graph_exact"],
+        "baseline_f1": report["baseline_f1"],
+        "graph_f1": report["graph_f1"],
+        "hits": report["hits"],
+        "evidence_recall": report["evidence_recall"],
+        "evidence_precision": report["evidence_precision"],
+    }, ensure_ascii=False, indent=2))
+    print("=== Accuracy Stats ===")
+    print(json.dumps(report.get("accuracy_stats", {}), ensure_ascii=False, indent=2))
+    print("=== Difficulty Scores ===")
+    print(json.dumps(report["difficulty_scores"], ensure_ascii=False, indent=2))
+    print("=== Route Stats ===")
+    print(json.dumps(report.get("route_stats", {}), ensure_ascii=False, indent=2))
+    print("=== Verification Stats ===")
+    print(json.dumps(report.get("verification_stats", {}), ensure_ascii=False, indent=2))
+    print("=== SFT Sampling Stats ===")
+    print(json.dumps(report.get("sft_sampling_stats", {}), ensure_ascii=False, indent=2))
+    print("=== Metrics By Difficulty Bucket ===")
+    print(json.dumps(report["metrics_by_difficulty_bucket"], ensure_ascii=False, indent=2))
+    print(f"saved: {args.out}")
+    if args.details_out is not None:
+        print(f"saved details: {args.details_out} ({args.details_format})")
+
+
+if __name__ == "__main__":
+    main()

--- a/deepresearch_qwen3_vl/lexical_graph.py
+++ b/deepresearch_qwen3_vl/lexical_graph.py
@@ -1,0 +1,190 @@
+from __future__ import annotations
+
+import math
+import re
+from collections import Counter, defaultdict
+from dataclasses import dataclass, field
+from typing import Iterable
+
+TOKEN_RE = re.compile(r"[A-Za-z0-9_\-\u4e00-\u9fff]+")
+STOPWORDS = {
+    "the",
+    "a",
+    "an",
+    "is",
+    "are",
+    "to",
+    "of",
+    "in",
+    "and",
+    "for",
+    "on",
+    "with",
+    "by",
+    "what",
+    "which",
+    "how",
+    "why",
+    "when",
+    "where",
+    "是",
+    "的",
+    "了",
+    "和",
+    "在",
+    "与",
+    "及",
+    "对",
+    "中",
+    "将",
+    "其",
+    "一个",
+}
+
+
+@dataclass
+class ChunkNode:
+    chunk_id: str
+    source: str
+    text: str
+    tokens: list[str]
+    entities: list[str]
+
+
+@dataclass
+class RetrievalResult:
+    chunk_id: str
+    source: str
+    text: str
+    score: float
+    reasons: list[str] = field(default_factory=list)
+
+
+class LexicalGraphIndex:
+    """In-memory lexical graph inspired by awslabs lexical-graph hierarchy.
+
+    Hierarchy we keep lightweight:
+      source -> chunk -> entity
+    plus inverted indexes for lexical retrieval and entity traversal.
+    """
+
+    def __init__(self) -> None:
+        self.chunks: dict[str, ChunkNode] = {}
+        self.source_to_chunks: dict[str, list[str]] = defaultdict(list)
+        self.entity_to_chunks: dict[str, set[str]] = defaultdict(set)
+        self.token_to_chunks: dict[str, set[str]] = defaultdict(set)
+
+    def add_document(self, source: str, text: str, chunk_size: int = 500) -> None:
+        clean = " ".join(text.split())
+        if not clean:
+            return
+        for i in range(0, len(clean), chunk_size):
+            chunk = clean[i : i + chunk_size]
+            chunk_id = f"{source}#c{i//chunk_size}"
+            tokens = _tokenize(chunk)
+            entities = _extract_entities(chunk)
+
+            node = ChunkNode(
+                chunk_id=chunk_id,
+                source=source,
+                text=chunk,
+                tokens=tokens,
+                entities=entities,
+            )
+            self.chunks[chunk_id] = node
+            self.source_to_chunks[source].append(chunk_id)
+            for t in set(tokens):
+                self.token_to_chunks[t].add(chunk_id)
+            for e in set(entities):
+                self.entity_to_chunks[e].add(chunk_id)
+
+    def has_data(self) -> bool:
+        return bool(self.chunks)
+
+
+class LexicalGraphRetriever:
+    """Traversal-based search approximation.
+
+    Step 1: lexical seed by token overlap (vector-search analogue).
+    Step 2: entity expansion to traverse related chunks (entity-network analogue).
+    Step 3: rerank by combined lexical + traversal support.
+    """
+
+    def __init__(self, index: LexicalGraphIndex) -> None:
+        self.index = index
+
+    def retrieve(self, question: str, top_k: int = 5) -> list[RetrievalResult]:
+        q_tokens = _tokenize(question)
+        if not q_tokens or not self.index.has_data():
+            return []
+
+        seed_scores: dict[str, float] = defaultdict(float)
+        for t in set(q_tokens):
+            chunks = self.index.token_to_chunks.get(t, set())
+            idf = math.log((1 + len(self.index.chunks)) / (1 + len(chunks))) + 1.0
+            for cid in chunks:
+                seed_scores[cid] += idf
+
+        seed_ids = sorted(seed_scores, key=lambda c: seed_scores[c], reverse=True)[: max(top_k, 3)]
+
+        expanded: dict[str, float] = defaultdict(float)
+        for cid in seed_ids:
+            expanded[cid] += seed_scores[cid]
+            entities = self.index.chunks[cid].entities
+            for ent in entities:
+                for neighbor_cid in self.index.entity_to_chunks.get(ent, set()):
+                    if neighbor_cid == cid:
+                        continue
+                    expanded[neighbor_cid] += 0.35 * seed_scores[cid]
+
+        results: list[RetrievalResult] = []
+        for cid, sc in expanded.items():
+            chunk = self.index.chunks[cid]
+            overlap = len(set(q_tokens) & set(chunk.tokens))
+            entity_overlap = len(set(_extract_entities(question)) & set(chunk.entities))
+            final_score = sc + 0.2 * overlap + 0.3 * entity_overlap
+            reasons = []
+            if cid in seed_ids:
+                reasons.append("lexical-seed")
+            if entity_overlap > 0:
+                reasons.append("entity-traversal")
+            results.append(
+                RetrievalResult(
+                    chunk_id=cid,
+                    source=chunk.source,
+                    text=chunk.text,
+                    score=final_score,
+                    reasons=reasons,
+                )
+            )
+
+        results.sort(key=lambda x: x.score, reverse=True)
+        return results[:top_k]
+
+
+def _tokenize(text: str) -> list[str]:
+    tokens = [x.lower() for x in TOKEN_RE.findall(text)]
+    return [t for t in tokens if t not in STOPWORDS and len(t) > 1]
+
+
+def _extract_entities(text: str) -> list[str]:
+    # Heuristic entities: CamelCase / AllCaps / Chinese words (len>=2)
+    raw = TOKEN_RE.findall(text)
+    ents: list[str] = []
+    for tok in raw:
+        if len(tok) < 2:
+            continue
+        if re.search(r"[\u4e00-\u9fff]", tok):
+            ents.append(tok)
+        elif tok[:1].isupper() and any(c.islower() for c in tok[1:]):
+            ents.append(tok)
+        elif tok.isupper() and len(tok) <= 8:
+            ents.append(tok)
+    return list(dict.fromkeys(ents))
+
+
+def build_graph_from_corpus(corpus: Iterable[tuple[str, str]]) -> LexicalGraphIndex:
+    index = LexicalGraphIndex()
+    for source, text in corpus:
+        index.add_document(source=source, text=text)
+    return index

--- a/deepresearch_qwen3_vl/main.py
+++ b/deepresearch_qwen3_vl/main.py
@@ -1,0 +1,47 @@
+from __future__ import annotations
+
+import argparse
+
+from agents import CriticAgent, PlannerAgent, ResearcherAgent, SynthesizerAgent, VerifierAgent
+from models import QwenVLClient
+from tools import SearchTool, ToolRouter, VisionTool, WebpageTool
+from workflow import DeepResearchWorkflow
+
+
+def build_workflow() -> DeepResearchWorkflow:
+    llm = QwenVLClient()
+
+    search_tool = SearchTool()
+    webpage_tool = WebpageTool()
+    vision_tool = VisionTool(vl_client=llm)
+    tool_router = ToolRouter(search_tool=search_tool, webpage_tool=webpage_tool, vision_tool=vision_tool)
+
+    planner = PlannerAgent(llm=llm)
+    researcher = ResearcherAgent(llm=llm, tool_router=tool_router)
+    critic = CriticAgent(llm=llm)
+    verifier = VerifierAgent(llm=llm)
+    synthesizer = SynthesizerAgent(llm=llm)
+
+    return DeepResearchWorkflow(
+        planner=planner,
+        researcher=researcher,
+        critic=critic,
+        verifier=verifier,
+        synthesizer=synthesizer,
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="DeepResearch with Qwen3-VL-8B-Instruct")
+    parser.add_argument("question", type=str, help="research question")
+    args = parser.parse_args()
+
+    workflow = build_workflow()
+    report = workflow.run(args.question)
+
+    print("\n=== Research Report ===\n")
+    print(report)
+
+
+if __name__ == "__main__":
+    main()

--- a/deepresearch_qwen3_vl/models.py
+++ b/deepresearch_qwen3_vl/models.py
@@ -1,0 +1,116 @@
+from __future__ import annotations
+
+import json
+import time
+from typing import Any
+
+from openai import APIConnectionError, NotFoundError, OpenAI
+
+from config import settings
+
+
+class QwenVLClient:
+    """OpenAI-compatible client wrapper for Qwen3-VL models."""
+
+    def __init__(self) -> None:
+        self.client = OpenAI(base_url=settings.api_base, api_key=settings.api_key, timeout=settings.api_timeout_s)
+        self.model = self._resolve_model_name(settings.model_name)
+
+    def _resolve_model_name(self, preferred: str) -> str:
+        """Pick an available model when preferred model ID does not exist on the server."""
+        try:
+            model_list = self.client.models.list()
+            available = [m.id for m in model_list.data if getattr(m, "id", None)]
+        except Exception:
+            return preferred
+
+        if not available:
+            return preferred
+        if preferred in available:
+            return preferred
+
+        preferred_tail = preferred.split("/")[-1].lower()
+        candidates = [
+            m
+            for m in available
+            if preferred_tail in m.lower() or m.lower() in preferred_tail or "qwen" in m.lower()
+        ]
+        chosen = candidates[0] if candidates else available[0]
+        print(
+            f"[QwenVLClient] configured model '{preferred}' not found; fallback to '{chosen}'. "
+            f"available={available}"
+        )
+        return chosen
+
+    def _get_available_models(self) -> list[str]:
+        try:
+            model_list = self.client.models.list()
+            return [m.id for m in model_list.data if getattr(m, "id", None)]
+        except Exception:
+            return []
+
+    def chat(self, messages: list[dict[str, Any]], temperature: float = 0.2) -> str:
+        last_error: Exception | None = None
+        for i in range(max(settings.api_retries, 1)):
+            try:
+                completion = self.client.chat.completions.create(
+                    model=self.model,
+                    messages=messages,
+                    temperature=temperature,
+                    max_tokens=max(settings.api_max_tokens, 1),
+                )
+                return completion.choices[0].message.content or ""
+            except NotFoundError as exc:
+                # model id mismatch between local vLLM served-model-name and configured MODEL_NAME
+                last_error = exc
+                available = self._get_available_models()
+                if available:
+                    new_model = available[0]
+                    if new_model != self.model:
+                        print(
+                            f"[QwenVLClient] model '{self.model}' not found at runtime; "
+                            f"retry with '{new_model}'. available={available}"
+                        )
+                        self.model = new_model
+                        continue
+                raise
+            except APIConnectionError as exc:
+                last_error = exc
+                if i < settings.api_retries - 1:
+                    time.sleep(settings.api_retry_backoff_s * (i + 1))
+                    continue
+                raise
+        if last_error:
+            raise last_error
+        return ""
+
+    def chat_json(self, messages: list[dict[str, Any]], fallback: Any, temperature: float = 0.1) -> Any:
+        raw = self.chat(messages=messages, temperature=temperature).strip()
+        try:
+            return json.loads(raw)
+        except json.JSONDecodeError:
+            pass
+
+        if "```" in raw:
+            chunks = raw.split("```")
+            for chunk in chunks:
+                text = chunk.strip()
+                if text.startswith("json"):
+                    text = text[4:].strip()
+                try:
+                    return json.loads(text)
+                except json.JSONDecodeError:
+                    continue
+        return fallback
+
+    def chat_with_image(self, prompt: str, image_url: str, temperature: float = 0.1) -> str:
+        messages: list[dict[str, Any]] = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    {"type": "image_url", "image_url": {"url": image_url}},
+                ],
+            }
+        ]
+        return self.chat(messages=messages, temperature=temperature)

--- a/deepresearch_qwen3_vl/requirements.txt
+++ b/deepresearch_qwen3_vl/requirements.txt
@@ -1,0 +1,56 @@
+# =========================
+# DeepResearch + Qwen3-VL(MoE) requirements
+# =========================
+
+# ---- Core runtime (current project code imports) ----
+openai==1.99.5
+httpx==0.27.2
+beautifulsoup4==4.12.3
+requests==2.32.5
+python-dotenv==1.1.1
+PyYAML==6.0.2
+tqdm==4.67.1
+
+# ---- Deep learning stack (for local multimodal inference) ----
+torch==2.7.1
+torchvision==0.22.1
+torchaudio==2.7.1
+triton==3.3.1
+xformers==0.0.31
+
+# ---- Transformers / HF (Qwen3-VL compatibility) ----
+# Qwen3-VL requires transformers >= 4.57.0
+transformers>=4.57.0,<5.0.0
+tokenizers==0.22.0
+huggingface-hub==0.34.4
+safetensors==0.6.2
+sentencepiece==0.2.1
+einops==0.8.1
+accelerate>=0.30.0
+qwen-vl-utils==0.0.14
+
+# ---- vLLM serving (Qwen3-VL) ----
+# Keep <0.12.0 to reduce CLI breaking changes with existing launch script.
+vllm>=0.11.0,<0.12.0
+
+# ---- Optional API/agent ecosystem used in typical DeepResearch deployments ----
+litellm==1.77.1
+dashscope==1.24.4
+qwen-agent==0.0.26
+modelscope==1.30.0
+
+# ---- Optional data / document processing ----
+numpy==2.2.6
+pandas==2.3.2
+opencv-python-headless==4.12.0.88
+pillow==11.3.0
+pdfplumber==0.11.7
+pdfminer.six==20250506
+openpyxl==3.1.5
+xlsxwriter==3.2.8
+lxml==6.0.1
+
+# ---- Utilities ----
+tenacity==9.1.2
+psutil==7.0.0
+ray==2.49.1

--- a/deepresearch_qwen3_vl/run_deepresearch.sh
+++ b/deepresearch_qwen3_vl/run_deepresearch.sh
@@ -1,0 +1,161 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+cd "$SCRIPT_DIR"
+
+print_help() {
+  cat <<'USAGE'
+Usage:
+  bash run_deepresearch.sh dashscope "<question>"
+  bash run_deepresearch.sh vllm-start-8b [model_path]
+  bash run_deepresearch.sh vllm-run-8b "<question>" [model_name_or_path]
+  bash run_deepresearch.sh eval /path/to/dataset.(json|jsonl|parquet) [--out /path/to/report.json] [--mock] [--image-root /path/to/images]
+
+Modes:
+  dashscope      Run DeepResearch via DashScope API.
+  vllm-start-8b  Start local vLLM for Qwen3-VL-8B default on GPUs 8,9 with TP=2.
+  vllm-run-8b    Run query against local vLLM, default model=Qwen/Qwen3-VL-8B-Instruct.
+  eval           Run eval_vqa.py with passed arguments.
+
+Required env for dashscope mode:
+  DASHSCOPE_API_KEY
+
+Examples:
+  # 8B two-card default (GPU 8,9)
+  bash run_deepresearch.sh vllm-start-8b
+  bash run_deepresearch.sh vllm-start-8b /data/models/Qwen3-VL-8B-Instruct
+  bash run_deepresearch.sh vllm-run-8b "请分析图文问答样例"
+
+OOM tuning envs for vLLM mode (optional):
+  VLLM_GPU_MEMORY_UTILIZATION (default 0.8)
+  VLLM_MAX_MODEL_LEN (default 4096)
+  VLLM_MAX_NUM_SEQS (default 1)
+  VLLM_MAX_NUM_BATCHED_TOKENS (default 1024)
+  VLLM_LIMIT_MM_PER_PROMPT (default {"image":1})
+
+OOM tuning envs for API client (optional):
+  API_MAX_TOKENS (default 128)
+USAGE
+}
+
+ensure_python() {
+  command -v python >/dev/null 2>&1 || {
+    echo "[ERROR] python not found in PATH"
+    exit 1
+  }
+}
+
+ensure_vllm() {
+  if ! python -c 'import vllm' >/dev/null 2>&1; then
+    echo "[ERROR] vllm is not installed. Please install requirements first."
+    exit 1
+  fi
+}
+
+run_dashscope() {
+  local question="${1:-}"
+  [[ -n "$question" ]] || { echo "[ERROR] missing question"; exit 1; }
+
+  : "${DASHSCOPE_API_KEY:?Please set DASHSCOPE_API_KEY}"
+  export OPENAI_BASE_URL="https://dashscope.aliyuncs.com/compatible-mode/v1"
+  export OPENAI_API_KEY="$DASHSCOPE_API_KEY"
+  export MODEL_NAME="${MODEL_NAME:-qwen-vl-max-latest}"
+
+  ensure_python
+  echo "[INFO] DashScope model=${MODEL_NAME}"
+  python main.py "$question"
+}
+
+start_vllm_server() {
+  local model_path="$1"
+  local tp_size="$2"
+  local gpu_ids="$3"
+  local port="${VLLM_PORT:-8000}"
+  local gpu_mem_util="${VLLM_GPU_MEMORY_UTILIZATION:-0.8}"
+  local max_model_len="${VLLM_MAX_MODEL_LEN:-4096}"
+  local max_num_seqs="${VLLM_MAX_NUM_SEQS:-1}"
+  local max_num_batched_tokens="${VLLM_MAX_NUM_BATCHED_TOKENS:-1024}"
+  local mm_limit="${VLLM_LIMIT_MM_PER_PROMPT:-}"
+  if [[ -z "$mm_limit" ]]; then
+    mm_limit='{"image":1}'
+  fi
+
+  ensure_python
+  ensure_vllm
+
+  export CUDA_VISIBLE_DEVICES="$gpu_ids"
+
+  cat <<INFO
+[INFO] Starting vLLM
+[INFO] model_path=${model_path}
+[INFO] tensor_parallel_size=${tp_size}
+[INFO] CUDA_VISIBLE_DEVICES=${CUDA_VISIBLE_DEVICES}
+[INFO] port=${port}
+[INFO] gpu_memory_utilization=${gpu_mem_util}
+[INFO] max_model_len=${max_model_len}
+[INFO] max_num_seqs=${max_num_seqs}
+[INFO] max_num_batched_tokens=${max_num_batched_tokens}
+[INFO] limit_mm_per_prompt=${mm_limit}
+INFO
+
+  python -m vllm.entrypoints.openai.api_server \
+    --model "$model_path" \
+    --served-model-name "$model_path" \
+    --host 0.0.0.0 \
+    --port "$port" \
+    --tensor-parallel-size "$tp_size" \
+    --gpu-memory-utilization "$gpu_mem_util" \
+    --max-model-len "$max_model_len" \
+    --max-num-seqs "$max_num_seqs" \
+    --max-num-batched-tokens "$max_num_batched_tokens" \
+    --limit-mm-per-prompt "$mm_limit"
+}
+
+run_vllm_start_8b() {
+  local model_path="${1:-${MODEL_NAME_8B:-Qwen/Qwen3-VL-8B-Instruct}}"
+  local tp_size="${VLLM_TP_SIZE_8B:-2}"
+  local gpu_ids="${CUDA_VISIBLE_DEVICES_8B:-8,9}"
+
+  start_vllm_server "$model_path" "$tp_size" "$gpu_ids"
+}
+
+run_vllm_query_8b() {
+  local question="${1:-}"
+  local model_name_arg="${2:-}"
+  [[ -n "$question" ]] || { echo "[ERROR] missing question"; exit 1; }
+
+  local port="${VLLM_PORT:-8000}"
+  local model_name="${MODEL_NAME_8B:-Qwen/Qwen3-VL-8B-Instruct}"
+  [[ -n "$model_name_arg" ]] && model_name="$model_name_arg"
+
+  export OPENAI_BASE_URL="http://127.0.0.1:${port}/v1"
+  export OPENAI_API_KEY="EMPTY"
+  export MODEL_NAME="$model_name"
+
+  ensure_python
+  echo "[INFO] Query model=${MODEL_NAME} via ${OPENAI_BASE_URL}"
+  python main.py "$question"
+}
+
+run_eval() {
+  ensure_python
+  python eval_vqa.py "$@"
+}
+
+main() {
+  local mode="${1:-help}"
+  shift || true
+
+  case "$mode" in
+    dashscope) run_dashscope "$@" ;;
+    vllm-start|vllm-start-8b) run_vllm_start_8b "$@" ;;
+    vllm-run-8b) run_vllm_query_8b "$@" ;;
+    vllm-run) run_vllm_query_8b "$@" ;;
+    eval) run_eval "$@" ;;
+    -h|--help|help) print_help ;;
+    *) echo "[ERROR] Unknown mode: $mode"; print_help; exit 1 ;;
+  esac
+}
+
+main "$@"

--- a/deepresearch_qwen3_vl/tools.py
+++ b/deepresearch_qwen3_vl/tools.py
@@ -1,0 +1,236 @@
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass
+from urllib.parse import urljoin
+
+import httpx
+from bs4 import BeautifulSoup
+
+from byokg_rag import BYOKGRAGProvider
+from config import settings
+from lexical_graph import LexicalGraphRetriever, build_graph_from_corpus
+from models import QwenVLClient
+
+
+@dataclass
+class SearchResult:
+    title: str
+    link: str
+    snippet: str
+
+
+@dataclass
+class ToolObservation:
+    tool_name: str
+    input_data: dict
+    output_data: str
+
+
+class SearchTool:
+    """Web search with custom API first and DuckDuckGo fallback."""
+
+    def search(self, query: str, top_k: int = 5) -> list[SearchResult]:
+        if settings.search_api_url and settings.search_api_key:
+            return self._search_custom(query=query, top_k=top_k)
+        return self._search_duckduckgo(query=query, top_k=top_k)
+
+    def _search_custom(self, query: str, top_k: int) -> list[SearchResult]:
+        headers = {"Authorization": f"Bearer {settings.search_api_key}"}
+        payload = {"q": query, "top_k": top_k}
+        with httpx.Client(timeout=20) as client:
+            resp = client.post(settings.search_api_url, headers=headers, json=payload)
+            resp.raise_for_status()
+            data = resp.json()
+
+        return [
+            SearchResult(
+                title=item.get("title", ""),
+                link=item.get("url", ""),
+                snippet=item.get("snippet", ""),
+            )
+            for item in data.get("results", [])[:top_k]
+        ]
+
+    def _search_duckduckgo(self, query: str, top_k: int) -> list[SearchResult]:
+        params = {"q": query, "format": "json", "no_html": 1, "skip_disambig": 1}
+        with httpx.Client(timeout=20) as client:
+            resp = client.get("https://api.duckduckgo.com/", params=params)
+            resp.raise_for_status()
+            data = resp.json()
+
+        results: list[SearchResult] = []
+        if data.get("AbstractText") or data.get("AbstractURL"):
+            results.append(
+                SearchResult(
+                    title=data.get("Heading", query),
+                    link=data.get("AbstractURL", ""),
+                    snippet=data.get("AbstractText", ""),
+                )
+            )
+
+        for topic in data.get("RelatedTopics", []):
+            if isinstance(topic, dict) and topic.get("Text") and topic.get("FirstURL"):
+                results.append(
+                    SearchResult(
+                        title=topic.get("Text", "").split(" - ")[0],
+                        link=topic.get("FirstURL", ""),
+                        snippet=topic.get("Text", ""),
+                    )
+                )
+            if len(results) >= top_k:
+                break
+        return results[:top_k]
+
+
+class WebpageTool:
+    def fetch_text(self, url: str, max_chars: int = 5000) -> str:
+        if not url:
+            return ""
+        with httpx.Client(timeout=20, follow_redirects=True) as client:
+            resp = client.get(url)
+            resp.raise_for_status()
+
+        soup = BeautifulSoup(resp.text, "html.parser")
+        for tag in soup(["script", "style", "noscript"]):
+            tag.extract()
+        text = " ".join(soup.get_text(separator=" ").split())
+        return text[:max_chars]
+
+    def extract_image_urls(self, url: str, max_images: int = 4) -> list[str]:
+        if not url:
+            return []
+        with httpx.Client(timeout=20, follow_redirects=True) as client:
+            resp = client.get(url)
+            resp.raise_for_status()
+
+        soup = BeautifulSoup(resp.text, "html.parser")
+        image_urls: list[str] = []
+        for img in soup.find_all("img"):
+            src = img.get("src")
+            if not src:
+                continue
+            absolute = urljoin(url, src)
+            if re.search(r"\.(png|jpg|jpeg|webp)(\?|$)", absolute.lower()):
+                image_urls.append(absolute)
+            if len(image_urls) >= max_images:
+                break
+        return image_urls
+
+
+class VisionTool:
+    """Use Qwen3-VL to summarize image evidence."""
+
+    def __init__(self, vl_client: QwenVLClient) -> None:
+        self.vl_client = vl_client
+
+    def describe_image(self, image_url: str, instruction: str = "提取图片中的关键信息并给出可信摘要") -> str:
+        prompt = (
+            f"{instruction}。要求：\n"
+            "1) 描述可见事实；\n"
+            "2) 标注不确定项；\n"
+            "3) 指出与研究问题直接相关的证据。"
+        )
+        return self.vl_client.chat_with_image(prompt=prompt, image_url=image_url)
+
+    def ocr_image(self, image_url: str) -> str:
+        prompt = (
+            "请对图片执行OCR并结构化输出可读文字。要求：\n"
+            "1) 只提取图中能明确辨认的文字；\n"
+            "2) 按区域或阅读顺序组织；\n"
+            "3) 若无文字则输出 NO_TEXT。"
+        )
+        return self.vl_client.chat_with_image(prompt=prompt, image_url=image_url)
+
+
+class LexicalGraphTool:
+    """Knowledge-enhanced retrieval for DeepResearch using lexical-graph ideas."""
+
+    def retrieve_from_documents(self, question: str, documents: list[tuple[str, str]], top_k: int = 5) -> list[str]:
+        index = build_graph_from_corpus(documents)
+        retriever = LexicalGraphRetriever(index)
+        results = retriever.retrieve(question=question, top_k=top_k)
+        return [
+            f"[{i+1}] source={r.source} score={r.score:.3f} reasons={','.join(r.reasons)} text={r.text[:500]}"
+            for i, r in enumerate(results)
+        ]
+
+
+class ToolRouter:
+    """Unified tool interface to support iterative agent tool-use."""
+
+    def __init__(
+        self,
+        search_tool: SearchTool,
+        webpage_tool: WebpageTool,
+        vision_tool: VisionTool,
+        lexical_graph_tool: LexicalGraphTool | None = None,
+        byokg_provider: BYOKGRAGProvider | None = None,
+    ) -> None:
+        self.search_tool = search_tool
+        self.webpage_tool = webpage_tool
+        self.vision_tool = vision_tool
+        self.lexical_graph_tool = lexical_graph_tool or LexicalGraphTool()
+        self.byokg_provider = byokg_provider or BYOKGRAGProvider()
+
+    def run(self, tool_name: str, args: dict) -> ToolObservation:
+        if tool_name == "search_web":
+            query = str(args.get("query", "")).strip()
+            top_k = int(args.get("top_k", settings.max_snippets_per_round))
+            results = self.search_tool.search(query=query, top_k=top_k)
+            compact = "\n".join(
+                [f"[{i+1}] {r.title} | {r.link} | {r.snippet}" for i, r in enumerate(results)]
+            )
+            return ToolObservation(tool_name=tool_name, input_data=args, output_data=compact)
+
+        if tool_name == "open_webpage":
+            url = str(args.get("url", "")).strip()
+            content = self.webpage_tool.fetch_text(url=url)
+            return ToolObservation(tool_name=tool_name, input_data=args, output_data=content)
+
+        if tool_name == "extract_images":
+            url = str(args.get("url", "")).strip()
+            images = self.webpage_tool.extract_image_urls(url=url)
+            return ToolObservation(tool_name=tool_name, input_data=args, output_data="\n".join(images))
+
+
+        if tool_name == "retrieve_lexical_graph":
+            question = str(args.get("question", "")).strip()
+            docs = args.get("documents", [])
+            top_k = int(args.get("top_k", settings.max_snippets_per_round))
+            normalized_docs: list[tuple[str, str]] = []
+            if isinstance(docs, list):
+                for d in docs:
+                    if isinstance(d, dict):
+                        source = str(d.get("source", "unknown"))
+                        text = str(d.get("text", ""))
+                        if text:
+                            normalized_docs.append((source, text))
+            out = self.lexical_graph_tool.retrieve_from_documents(question=question, documents=normalized_docs, top_k=top_k)
+            return ToolObservation(tool_name=tool_name, input_data=args, output_data="\n".join(out))
+
+        if tool_name == "analyze_image":
+            image_url = str(args.get("image_url", "")).strip()
+            question = str(args.get("question", "")).strip() or "提取图片关键证据"
+            result = self.vision_tool.describe_image(image_url=image_url, instruction=question)
+            return ToolObservation(tool_name=tool_name, input_data=args, output_data=result)
+
+        if tool_name == "ocr_image":
+            image_url = str(args.get("image_url", "")).strip()
+            result = self.vision_tool.ocr_image(image_url=image_url)
+            return ToolObservation(tool_name=tool_name, input_data=args, output_data=result)
+
+        if tool_name == "retrieve_graph_evidence":
+            question = str(args.get("question", "")).strip()
+            schema = args.get("schema", {})
+            graph_context = args.get("graph_context")
+            if not isinstance(schema, dict):
+                schema = {}
+            result = self.byokg_provider.retrieve_graph_evidence(
+                question=question,
+                schema=schema,
+                graph_context=str(graph_context) if graph_context is not None else None,
+            )
+            return ToolObservation(tool_name=tool_name, input_data=args, output_data=str(result))
+
+        raise ValueError(f"Unsupported tool: {tool_name}")

--- a/deepresearch_qwen3_vl/workflow.py
+++ b/deepresearch_qwen3_vl/workflow.py
@@ -1,0 +1,81 @@
+from __future__ import annotations
+
+from agents import (
+    CriticAgent,
+    PlannerAgent,
+    ResearchState,
+    ResearcherAgent,
+    SubQuestion,
+    SynthesizerAgent,
+    VerifierAgent,
+)
+from config import settings
+
+
+class DeepResearchWorkflow:
+    """
+    DeepResearch-like pipeline:
+    plan -> investigate(with tool actions) -> critique -> iterate -> verify -> synthesize
+    """
+
+    def __init__(
+        self,
+        planner: PlannerAgent,
+        researcher: ResearcherAgent,
+        critic: CriticAgent,
+        verifier: VerifierAgent,
+        synthesizer: SynthesizerAgent,
+    ) -> None:
+        self.planner = planner
+        self.researcher = researcher
+        self.critic = critic
+        self.verifier = verifier
+        self.synthesizer = synthesizer
+
+    @staticmethod
+    def _score_evidence_importance(question: str, evidence: Evidence) -> float:
+        q_terms = {t for t in question.lower().split() if t}
+        text = f"{evidence.claim} {evidence.excerpt}".lower()
+        overlap = sum(1 for t in q_terms if t in text)
+        overlap_score = overlap / max(len(q_terms), 1)
+        return 0.7 * evidence.confidence + 0.3 * overlap_score
+
+    def _compress_state_memory(self, state: ResearchState) -> None:
+        if len(state.evidence) > settings.max_evidence_items:
+            ranked = sorted(
+                state.evidence,
+                key=lambda e: self._score_evidence_importance(state.question, e),
+                reverse=True,
+            )
+            state.evidence = ranked[: settings.max_evidence_items]
+
+        if len(state.tool_logs) > settings.max_tool_logs:
+            state.tool_logs = state.tool_logs[-settings.max_tool_logs :]
+
+    def run(self, question: str) -> str:
+        state = ResearchState(question=question)
+        state.sub_questions = self.planner.plan(question)
+
+        for _ in range(settings.max_rounds):
+            current_questions = state.sub_questions[:]
+            state.sub_questions = []
+
+            for sq in current_questions:
+                ev, logs = self.researcher.investigate(main_question=state.question, sub_question=sq)
+                state.evidence.extend(ev)
+                state.tool_logs.extend(logs)
+                self._compress_state_memory(state)
+
+            critique = self.critic.critique(question=state.question, evidence=state.evidence)
+            if critique.sufficient:
+                break
+
+            if critique.follow_up_questions:
+                state.sub_questions = [
+                    SubQuestion(question=q, intent="gap_fill", priority=1) for q in critique.follow_up_questions
+                ]
+            else:
+                state.sub_questions = [SubQuestion(question=state.question, intent="fallback", priority=1)]
+
+        state.evidence = self.verifier.verify(question=state.question, evidence=state.evidence)
+        return self.synthesizer.synthesize(state)

--- a/deepresearch_qwen3_vl/程序运行流程.md
+++ b/deepresearch_qwen3_vl/程序运行流程.md
@@ -1,0 +1,204 @@
+# DeepResearch Qwen3-VL 程序运行流程
+
+本文描述当前 `deepresearch_qwen3_vl` 项目的两条主链路：
+
+1. **问答推理主流程**（`main.py` + `workflow.py`）
+2. **VQA 评估流程**（`eval_vqa.py`）
+
+---
+
+## 1) 问答推理主流程（DeepResearch Workflow）
+
+### 1.1 入口与组件初始化
+
+运行：
+
+```bash
+python main.py "你的问题"
+```
+
+程序会在 `build_workflow()` 中完成以下初始化：
+
+- 大模型客户端：`QwenVLClient`
+- 工具层：`SearchTool`、`WebpageTool`、`VisionTool`、`ToolRouter`
+- 智能体：`PlannerAgent`、`ResearcherAgent`、`CriticAgent`、`VerifierAgent`、`SynthesizerAgent`
+- 最终组装：`DeepResearchWorkflow`
+
+当前多模态代理骨架已经覆盖的关键能力包括：
+
+- 图像理解：`analyze_image`
+- OCR 抽取：`ocr_image`
+- 图文联合检索：`retrieve_lexical_graph`
+- 图谱证据获取：`retrieve_graph_evidence`
+
+### 1.2 工作流阶段
+
+`DeepResearchWorkflow.run(question)` 的阶段如下：
+
+1. **规划阶段（Plan）**
+   - `PlannerAgent` 将主问题拆解为多个子问题。
+
+2. **多轮调查阶段（Investigate）**
+   - 按 `MAX_RESEARCH_ROUNDS` 控制轮次。
+   - 每轮中，`ResearcherAgent` 对每个子问题调用工具（搜索、网页、视觉、OCR、图谱证据）收集证据。
+   - 每次累计证据后，工作流会执行“重要性评分驱动的记忆压缩”，仅保留高置信且与主问题更相关的证据与最近工具日志。
+
+3. **批判与补充阶段（Critique）**
+   - `CriticAgent` 判断证据是否充分。
+   - 若不足，生成 follow-up 子问题，进入下一轮。
+
+4. **校验阶段（Verify）**
+   - `VerifierAgent` 对证据进行一致性与有效性过滤。
+
+5. **汇总生成阶段（Synthesize）**
+   - `SynthesizerAgent` 生成最终研究报告并返回。
+
+---
+
+## 2) VQA 评估流程（eval_vqa.py）
+
+### 2.1 入口与输入
+
+运行示例：
+
+```bash
+python eval_vqa.py /path/to/dataset.jsonl --out report.json
+```
+
+支持：
+
+- `json` / `jsonl` / `parquet`
+- 目录形式的 parquet 分片（会自动合并 `*.parquet`）
+
+### 2.2 数据归一化
+
+`load_dataset()` 会先读原始记录，再按 `--dataset-type` 走不同归一化逻辑：
+
+- `generic`：A-OKVQA 风格
+- `m3cot`：M3COT 风格（字母答案映射到选项文本）
+- `mmmu_pro`：MMMU-Pro 风格（支持 `choices/options/option_a..option_j`，并可与 vision parquet 进行 join）
+
+每条样本都会保留：
+
+- `question`、`answer`、`documents`
+- 图像引用字段（`image_url/image_path/image/__image_bytes`）
+- `__original_record`（原始记录快照）
+
+### 2.3 断点续跑与进度
+
+- `--resume-from`：从既有 details 文件恢复，跳过已完成样本
+- `--save-every N`：每 N 条写一次 checkpoint 到 `--details-out`
+- 进度条：`tqdm` 展示 `baseline_err/graph_err/img`
+
+### 2.4 单条样本评测步骤
+
+对每个样本，评估器会做：
+
+1. 解析图像引用（URL、本地路径、bytes）
+2. 组装 `baseline_context`
+3. 先计算难度分项（dataset-aware）：
+   - A-OKVQA / M3COT / MMMU-Pro 各自逻辑
+4. 根据 `difficulty.overall` 生成路由标签：
+   - `direct_inference`：跳过图检索，直接推理
+   - `light_rag`：单轮 lexical graph 检索
+   - `full_rag`：双轮 lexical graph 检索，第二轮使用首轮证据片段扩展查询补证
+5. 依据路由构建 `graph_context`
+6. 调用 LLM 生成：
+   - baseline 预测
+   - graph 预测
+7. 计算 `exact`、`token_f1`、`hits / evidence_recall / evidence_precision`
+8. 生成 `Verified / Unverified` 标记
+9. 写入详情记录（含 `sample_key`、`difficulty.route`、`retrieval_trace`）
+
+### 2.5 难度分级（三等分分位数）
+
+不是固定阈值，而是：
+
+1. 先收集所有样本 `difficulty.overall`
+2. 计算 q33 与 q67
+3. 依据 q33/q67 分成 `easy/medium/hard`
+4. 在报告中输出 `difficulty_bucket_thresholds`
+
+当前难度建模已进一步对齐为四个主维度：
+
+- `H`：推理跳数 / 推理深度
+- `D`：推理干扰
+- `O`：逻辑复杂度
+- `A`：模态对齐难度
+
+并按任务类型使用不同权重：
+
+- `knowledge_enhanced_vqa`：`[H,D,O,A] = [0.20, 0.25, 0.10, 0.35]`
+- `ordinary_multimodal_vqa`：`[H,D,O,A] = [0.30, 0.25, 0.15, 0.30]`
+
+同时会输出 `qnorm_100`（0-100 量纲）便于和论文/技术路线中的难度分数表述对齐。
+
+### 2.5.1 难度感知路由与验证统计
+
+为对齐 DAMKEF 技术路线图，当前评测输出还包含：
+
+- `difficulty.route`：`direct_inference / light_rag / full_rag`
+- `verification`：`Verified / Unverified`
+- `route_stats`：三类路由的样本数量
+- `verification_stats`：
+  - `verified`
+  - `unverified`
+  - `hard_verified`
+  - `hard_unverified`
+- `sft_sampling_stats`
+  - `hard_unverified_primary`
+  - `hard_verified_aux`
+
+这些字段可直接用于：
+
+- 分析 Easy/Medium/Hard 的工具调用分布
+- 筛选 `Hard Verified` / `Hard Unverified` 样本
+- 对接后续 SFT 训练集构建流程（当前默认标签与 `90% Hard Unverified + 10% Hard Verified` 采样策略兼容）
+
+### 2.6 结果产物
+
+- `--out`：汇总 JSON（全局指标 + 分桶指标 + 阈值 + details）
+- `--details-out`（可选）：
+  - `json`：数组
+  - `jsonl`：逐行记录
+
+---
+
+## 3) 推荐运行顺序
+
+1. 先小样本 `--mock` 验证流程
+2. 再连接 vLLM 做真实评估
+3. 大规模数据开启：
+   - `--details-out`
+   - `--save-every`
+   - `--resume-from`
+
+这样能兼顾稳定性与可恢复性。
+
+---
+
+## 4) BYOKG-RAG 图证据获取模块（新增）
+
+项目新增 `byokg_rag.py`，将 BYOKG-RAG 抽象为 **Graph Evidence Provider**。
+
+### 4.1 输入输出
+
+- 输入：`question + schema (+ optional graph_context)`
+- 输出：
+  - `graph_evidence`（triples/paths/query_results/image_evidence）
+  - `linking_artifacts`（entities/paths/dsl/opencypher/refinement_history）
+  - `confidence/coverage`
+
+### 4.2 工具层接入
+
+`ToolRouter` 新增 `retrieve_graph_evidence` 工具名，调用 `BYOKGRAGProvider` 执行图证据获取。
+
+### 4.3 核心工程增强
+
+- 迭代 refinement（full → repair-only）
+- validator（实体/路径/schema/OpenCypher/dry-run）
+- DSL→Cypher 编译器（减少自由生成 Cypher 错误）
+- 按 KG 稠密度与问题类型动态设置 reranker 参数 `L/k`
+- 多策略 linking（entity_path / relation_path / query_shape）与策略重排融合
+- 基于问题词的 schema focus/pruning（`focus_relation_types`）
+- 可选 Cypher 执行器回填 `query_results`，并参与 coverage 估计


### PR DESCRIPTION
### Motivation
- Introduce a modular Graph Evidence Provider (BYOKG-RAG) and lexical-graph retrieval to provide schema-constrained, multi-strategy KG evidence for knowledge-enhanced multimodal VQA and research workflows.  
- Provide a unified DeepResearch workflow around `Qwen3-VL` for iterative tool-driven research (planning, investigating, critiquing, verifying, synthesizing).  
- Add a dataset-aware VQA evaluation harness that supports A-OKVQA/M3COT/MMMU-Pro/ScienceQA styles with difficulty estimation and route-aware retrieval.  
- Bundle utilities and run scripts to ease local vLLM / DashScope usage and reproducible evaluations.

### Description
- Added a BYOKG-RAG provider (`byokg_rag.py`) implementing `BYOKGRAGProvider`, `BYOKGValidator`, `CypherDSLCompiler`, multi-strategy linking (`entity_path`, `relation_path`, `query_shape`), dynamic reranker, DSL→Cypher compilation, iterative refinement and optional `cypher_executor` query backfill.  
- Implemented lexical-graph index and retriever (`lexical_graph.py`) with token/entity inverted indexes, traversal expansion and reranking, and `build_graph_from_corpus` helper.  
- Built a full evaluation pipeline `eval_vqa.py` with dataset normalization, difficulty estimator (`difficulty.py`), route-aware lexical-graph retrieval, baseline vs graph predictions, metrics aggregation and checkpointing.  
- Integrated agents/workflow/tools (`agents.py`, `workflow.py`, `tools.py`, `models.py`, `main.py`) and helper artifacts: README, docs (`程序运行流程.md`, VQA report notes), `run_deepresearch.sh`, `requirements.txt`, and `.gitignore` to form a runnable DeepResearch project scaffold exposing `retrieve_graph_evidence` via `ToolRouter`.

### Testing
- No automated tests were executed as part of this change (no CI/test scripts were included in this rollout).  
- The change is organized for manual smoke-testing via `python main.py` and `python eval_vqa.py` and for local vLLM runs via `bash run_deepresearch.sh` if desired.  
- Consumers should run import/smoke checks such as `python -c "import deepresearch_qwen3_vl"` and try `python eval_vqa.py --mock` before integrating into CI.  
- Recommended next steps are to add unit tests for `lexical_graph`, `byokg_rag` validation logic, and end-to-end integration tests for `eval_vqa.py`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698db459dbc4832ea03ac68c1d294321)